### PR TITLE
Fix react devtools loading within an iframe.

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -1,3 +1,10 @@
+// Detect if this is a child frame. If yes, initialize the react devtools hook to work around
+//   https://github.com/facebook/react-devtools/issues/57
+// This must occur before any react code is loaded.
+if (window.parent !== window) {
+  window.__REACT_DEVTOOLS_GLOBAL_HOOK__ = window.parent.__REACT_DEVTOOLS_GLOBAL_HOOK__;
+}
+
 require('../assets/css/main.scss');
 
 // Get our browser up to date with polyfills.


### PR DESCRIPTION
Allows use devtools with http://localhost:3000/webpack-dev-server/ to
get all the hot-reload goodness.
