### PR TITLE
Change required indication

### DIFF
--- a/assets/css/hca.scss
+++ b/assets/css/hca.scss
@@ -102,6 +102,11 @@ select {
   }
 }
 
+.hca-required-span {
+  color: $color-secondary-dark;
+  margin: 0 0.35em;
+}
+
 .hca-process {
   li {
     h5 {

--- a/src/client/components/form-elements/DateInput.jsx
+++ b/src/client/components/form-elements/DateInput.jsx
@@ -58,9 +58,18 @@ class DateInput extends React.Component {
           validateIfDirtyDate(day, month, year, isValidDate);
     }
 
+    // Calculate required.
+    let requiredSpan = undefined;
+    if (this.props.required) {
+      requiredSpan = <span className="hca-required-span">*</span>;
+    }
+
     return (
       <div>
-        <label>{this.props.label ? this.props.label : 'Date of Birth'}</label>
+        <label>
+          {this.props.label ? this.props.label : 'Date of Birth'}
+          {requiredSpan}
+        </label>
         <span className="usa-form-hint usa-datefield-hint" id="dobHint">For example: Apr 28 1986</span>
         <div className={isValid ? undefined : 'usa-input-error'}>
           <div className="usa-date-of-birth row">

--- a/src/client/components/form-elements/ErrorableCheckbox.jsx
+++ b/src/client/components/form-elements/ErrorableCheckbox.jsx
@@ -37,9 +37,9 @@ class ErrorableCheckbox extends React.Component {
     }
 
     // Calculate required.
-    let requiredSpan = '';
+    let requiredSpan = undefined;
     if (this.props.required) {
-      requiredSpan = <span className="usa-additional_text">Required</span>;
+      requiredSpan = <span className="hca-required-span">*</span>;
     }
 
     return (

--- a/src/client/components/form-elements/ErrorableNumberInput.jsx
+++ b/src/client/components/form-elements/ErrorableNumberInput.jsx
@@ -46,9 +46,9 @@ class ErrorableNumberInput extends React.Component {
     }
 
     // Calculate required.
-    let requiredSpan = '';
+    let requiredSpan = undefined;
     if (this.props.required) {
-      requiredSpan = <span className="usa-additional_text">Required</span>;
+      requiredSpan = <span className="hca-required-span">*</span>;
     }
 
     return (

--- a/src/client/components/form-elements/ErrorableRadioButtons.jsx
+++ b/src/client/components/form-elements/ErrorableRadioButtons.jsx
@@ -37,9 +37,9 @@ class ErrorableRadioButtons extends React.Component {
     }
 
     // Calculate required.
-    let requiredSpan = '';
+    let requiredSpan = undefined;
     if (this.props.required) {
-      requiredSpan = <span className="usa-additional_text">Required</span>;
+      requiredSpan = <span className="hca-required-span">*</span>;
     }
 
     const options = _.isArray(this.props.options) ? this.props.options : [];

--- a/src/client/components/form-elements/ErrorableSelect.jsx
+++ b/src/client/components/form-elements/ErrorableSelect.jsx
@@ -39,9 +39,9 @@ class ErrorableSelect extends React.Component {
     }
 
     // Calculate required.
-    let requiredSpan = '';
+    let requiredSpan = undefined;
     if (this.props.required) {
-      requiredSpan = <span className="usa-additional_text">Required</span>;
+      requiredSpan = <span className="hca-required-span">*</span>;
     }
 
     // Calculate options for select

--- a/src/client/components/form-elements/ErrorableTextInput.jsx
+++ b/src/client/components/form-elements/ErrorableTextInput.jsx
@@ -43,9 +43,9 @@ class ErrorableTextInput extends React.Component {
     }
 
     // Calculate required.
-    let requiredSpan = '';
+    let requiredSpan = undefined;
     if (this.props.required) {
-      requiredSpan = <span className="usa-additional_text">Required</span>;
+      requiredSpan = <span className="hca-required-span">*</span>;
     }
 
     return (

--- a/src/client/components/personal-information/AdditionalInformationSection.jsx
+++ b/src/client/components/personal-information/AdditionalInformationSection.jsx
@@ -37,6 +37,7 @@ class AdditionalInformationSection extends React.Component {
       </table>);
     } else {
       content = (<div>
+        <p>(<span className="hca-required-span">*</span>) Indicates a required field</p>
         <div className="input-section">
           <ErrorableCheckbox
               label="I am enrolling to obtain minimal essential coverage under the affordable care act"

--- a/src/client/components/personal-information/NameAndGeneralInfoSection.jsx
+++ b/src/client/components/personal-information/NameAndGeneralInfoSection.jsx
@@ -58,6 +58,7 @@ class NameAndGeneralInfoSection extends React.Component {
       </table>);
     } else {
       content = (<div>
+        <p>(<span className="hca-required-span">*</span>) Indicates a required field</p>
         <div className="input-section">
           <FullName required
               name={this.props.data.fullName}

--- a/src/client/components/personal-information/VAInformationSection.jsx
+++ b/src/client/components/personal-information/VAInformationSection.jsx
@@ -42,7 +42,7 @@ class VaInformationSection extends React.Component {
           This information will be used to determine which sections of the Application for
           Health Benefits you should complete.
         </p>
-
+        <p>(<span className="hca-required-span">*</span>) Indicates a required field</p>
         <div className="input-section">
           <ErrorableRadioButtons required
               errorMessage={validateIfDirty(this.props.data.isVaServiceConnected, isNotBlank) ? '' : 'Please select a response'}

--- a/test/client/components/form-elements/ErrorableCheckbox.spec.jsx
+++ b/test/client/components/form-elements/ErrorableCheckbox.spec.jsx
@@ -119,20 +119,19 @@ describe('<ErrorableCheckbox>', () => {
     expect(inputs[0].props['aria-describedby']).to.equal(errorMessages[0].props.id);
   });
 
-  it('required=false does not have required span', () => {
+  it('required=false does not have required asterisk', () => {
     const tree = SkinDeep.shallowRender(
       <ErrorableCheckbox label="my label" onValueChange={(_update) => {}}/>);
 
-    expect(tree.everySubTree('.usa-additional_text')).to.have.lengthOf(0);
+    expect(tree.everySubTree('label')[0].text()).to.equal('my label');
   });
 
-  it('required=true has required span', () => {
+  it('required=true has required asterisk', () => {
     const tree = SkinDeep.shallowRender(
       <ErrorableCheckbox label="my label" required onValueChange={(_update) => {}}/>);
 
-    const requiredSpan = tree.everySubTree('.usa-additional_text');
-    expect(requiredSpan).to.have.lengthOf(1);
-    expect(requiredSpan[0].text()).to.equal('Required');
+    const label = tree.everySubTree('label');
+    expect(label[0].text()).to.equal('my label*');
   });
 
   it('label attribute propagates', () => {

--- a/test/client/components/form-elements/ErrorableNumberInput.spec.jsx
+++ b/test/client/components/form-elements/ErrorableNumberInput.spec.jsx
@@ -145,20 +145,19 @@ describe('<ErrorableNumberInput>', () => {
     expect(inputs[0].props['aria-describedby']).to.equal(errorMessages[0].props.id);
   });
 
-  it('required=false does not have required span', () => {
+  it('required=false does not have required asterisk', () => {
     const tree = SkinDeep.shallowRender(
       <ErrorableNumberInput field={testValue} label="my label" onValueChange={(_update) => {}}/>);
 
-    expect(tree.everySubTree('.usa-additional_text')).to.have.lengthOf(0);
+    expect(tree.everySubTree('label')[0].text()).to.equal('my label');
   });
 
-  it('required=true has required span', () => {
+  it('required=true has required asterisk', () => {
     const tree = SkinDeep.shallowRender(
       <ErrorableNumberInput field={testValue} label="my label" required onValueChange={(_update) => {}}/>);
 
-    const requiredSpan = tree.everySubTree('.usa-additional_text');
-    expect(requiredSpan).to.have.lengthOf(1);
-    expect(requiredSpan[0].text()).to.equal('Required');
+    const label = tree.everySubTree('label');
+    expect(label[0].text()).to.equal('my label*');
   });
 
   it('label attribute propagates', () => {

--- a/test/client/components/form-elements/ErrorableSelect.spec.jsx
+++ b/test/client/components/form-elements/ErrorableSelect.spec.jsx
@@ -135,20 +135,19 @@ describe('<ErrorableSelect>', () => {
     expect(selects[0].props['aria-describedby']).to.equal(errorMessages[0].props.id);
   });
 
-  it('required=false does not have required span', () => {
+  it('required=false does not have required asterisk', () => {
     const tree = SkinDeep.shallowRender(
       <ErrorableSelect label="my label" options={options} value={testValue} onValueChange={(_update) => {}}/>);
 
-    expect(tree.everySubTree('.usa-additional_text')).to.have.lengthOf(0);
+    expect(tree.everySubTree('label')[0].text()).to.equal('my label');
   });
 
-  it('required=true has required span', () => {
+  it('required=true has required asterisk', () => {
     const tree = SkinDeep.shallowRender(
       <ErrorableSelect label="my label" options={options} required value={testValue} onValueChange={(_update) => {}}/>);
 
-    const requiredSpan = tree.everySubTree('.usa-additional_text');
-    expect(requiredSpan).to.have.lengthOf(1);
-    expect(requiredSpan[0].text()).to.equal('Required');
+    const label = tree.everySubTree('label');
+    expect(label[0].text()).to.equal('my label*');
   });
 
   it('label attribute propagates', () => {

--- a/test/client/components/form-elements/ErrorableTextInput.spec.jsx
+++ b/test/client/components/form-elements/ErrorableTextInput.spec.jsx
@@ -126,20 +126,19 @@ describe('<ErrorableTextInput>', () => {
     expect(inputs[0].props['aria-describedby']).to.equal(errorMessages[0].props.id);
   });
 
-  it('required=false does not have required span', () => {
+  it('required=false does not have required asterisk', () => {
     const tree = SkinDeep.shallowRender(
       <ErrorableTextInput field={makeField(1)} label="my label" onValueChange={(_update) => {}}/>);
 
-    expect(tree.everySubTree('.usa-additional_text')).to.have.lengthOf(0);
+    expect(tree.everySubTree('label')[0].text()).to.equal('my label');
   });
 
-  it('required=true has required span', () => {
+  it('required=true has required asterisk', () => {
     const tree = SkinDeep.shallowRender(
       <ErrorableTextInput field={makeField(1)} label="my label" required onValueChange={(_update) => {}}/>);
 
-    const requiredSpan = tree.everySubTree('.usa-additional_text');
-    expect(requiredSpan).to.have.lengthOf(1);
-    expect(requiredSpan[0].text()).to.equal('Required');
+    const label = tree.everySubTree('label');
+    expect(label[0].text()).to.equal('my label*');
   });
 
   it('label attribute propagates', () => {


### PR DESCRIPTION
From user testing we found that some users had trouble understanding what the "Required" span was indicating. We are instead going to use asterisks to indicate required fields. 

Screenshot (ignore the condensed column of questions, something is messed up with our styles):
<img width="1172" alt="screenshot 2016-05-02 10 09 50" src="https://cloud.githubusercontent.com/assets/3886085/14957405/3e174628-1053-11e6-8052-11b934fb297d.png">

@maryannbrody @gnakm Would love to get your input as well on this method of indicating required fields. Should we may the asterisk red?
