### PR TITLE
Add react-scroll and use that to handle scrolling

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "phantomjs-prebuilt": "^2.1.4",
     "react-addons-test-utils": "^15.0.1",
     "react-redux": "^4.4.5",
+    "react-scroll": "^1.0.15",
     "react-transform-catch-errors": "^1.0.2",
     "react-transform-hmr": "^1.0.2",
     "redbox-react": "^1.2.2",

--- a/src/client/components/HealthCareApp.jsx
+++ b/src/client/components/HealthCareApp.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import Scroll from 'react-scroll';
 import { hashHistory } from 'react-router';
 
 import IntroductionSection from './IntroductionSection.jsx';
@@ -8,6 +9,9 @@ import { ensureFieldsInitialized, updateCompletionStatus, updateSubmissionStatus
 import { pathToData } from '../store';
 
 import * as validations from '../utils/validations';
+
+const Element = Scroll.Element;
+const scroller = Scroll.scroller;
 
 class HealthCareApp extends React.Component {
   constructor() {
@@ -45,6 +49,14 @@ class HealthCareApp extends React.Component {
     return nextPath;
   }
 
+  scrollToTop() {
+    scroller.scrollTo('topScrollElement', {
+      duration: 500,
+      delay: 0,
+      smooth: true,
+    });
+  }
+
   handleContinue() {
     const path = this.props.location.pathname;
     const sectionData = pathToData(this.context.store.getState().veteran, path);
@@ -53,31 +65,21 @@ class HealthCareApp extends React.Component {
     if (validations.isValidSection(path, sectionData)) {
       hashHistory.push(this.getUrl('next'));
       this.context.store.dispatch(updateCompletionStatus(path));
-      if (document.getElementsByClassName('progress-box').length > 0) {
-        document.getElementsByClassName('progress-box')[0].scrollIntoView();
-      }
-    } else {
-      // TODO: improve this
-      if (document.getElementsByClassName('usa-input-error').length > 0) {
-        document.getElementsByClassName('usa-input-error')[0].scrollIntoView();
-      }
     }
+
+    this.scrollToTop();
   }
 
   handleBack() {
     hashHistory.push(this.getUrl('back'));
-    if (document.getElementsByClassName('progress-box').length > 0) {
-      document.getElementsByClassName('progress-box')[0].scrollIntoView();
-    }
+    this.scrollToTop();
   }
 
   handleSubmit() {
     const path = this.props.location.pathname;
     this.context.store.dispatch(updateSubmissionStatus('applicationSubmitted'));
     this.context.store.dispatch(updateCompletionStatus(path));
-    if (document.getElementsByTagName('h4').length > 0) {
-      document.getElementsByTagName('h4')[0].scrollIntoView();
-    }
+    this.scrollToTop();
   }
 
   render() {
@@ -141,6 +143,7 @@ class HealthCareApp extends React.Component {
 
     return (
       <div className="row">
+        <Element name="topScrollElement"/>
         <div className="medium-4 columns show-for-medium-up">
           <Nav currentUrl={this.props.location.pathname}/>
         </div>

--- a/src/client/components/form-elements/GrowableTable.jsx
+++ b/src/client/components/form-elements/GrowableTable.jsx
@@ -1,7 +1,11 @@
 import React from 'react';
+import Scroll from 'react-scroll';
 import _ from 'lodash';
 
 import * as validations from '../../utils/validations';
+
+const Element = Scroll.Element;
+const scroller = Scroll.scroller;
 
 class GrowableTable extends React.Component {
   constructor(props) {
@@ -29,6 +33,14 @@ class GrowableTable extends React.Component {
     }
   }
 
+  scrollToTop() {
+    scroller.scrollTo('topOfTable', {
+      duration: 500,
+      delay: 0,
+      smooth: true,
+    });
+  }
+
   createNewElement() {
     const blankRowData = this.props.createRow();
     blankRowData.key = _.uniqueId('key-');
@@ -54,12 +66,9 @@ class GrowableTable extends React.Component {
 
     if (validations.isValidSection(this.props.path, this.props.data)) {
       this.setState({ [event.target.dataset.key]: 'complete' });
-      document.getElementsByClassName('input-section')[1].scrollIntoView();
-    } else {
-      // TODO: figure out how to deal with the fact that this runs before the
-      // child component renders, so there will be no error classes yet
-      document.getElementsByClassName('usa-input-error')[0].scrollIntoView();
     }
+
+    this.scrollToTop();
   }
 
   handleRemove(event) {
@@ -146,6 +155,7 @@ class GrowableTable extends React.Component {
 
     return (
       <div>
+        <Element name="topOfTable"/>
         {rowElements}
         <div className="row">
           <div className="small-3 small-centered columns">


### PR DESCRIPTION
Fix how we were handling scrolling before by using `react-scroll` and scrolling to an element at the top of the page. I think this is better than searching the DOM for specific nodes and scrolling to those using plain old JS, but it also gives us less control over where we're scrolling to. As far as I can tell there's no way to scroll to a particular error field using `react-scroll`. Instead, I'm always scrolling to the top of the form. I think this is okay because 1) scrolling to a particular error field wasn't working before anyway (wouldn't scroll until the second time you click on the button because of when the function is being called in relation to when the error classes are added to the page), and 2) in our new version of the form with fewer questions and shorter answers, you should be able to see all error fields if we scroll to the top anyway. 
