### PR TITLE
Update store

### DIFF
--- a/src/client/actions/index.js
+++ b/src/client/actions/index.js
@@ -8,10 +8,11 @@ export const UPDATE_SPOUSE_ADDRESS = 'UPDATE_SPOUSE_ADDRESS';
 export const UPDATE_SUBMISSION_STATUS = 'UPDATE_SUBMISSION_STATUS';
 export const CREATE_CHILD_INCOME_FIELDS = 'CREATE_CHILD_INCOME_FIELDS';
 
-export function ensureFieldsInitialized(path) {
+export function ensureFieldsInitialized(fields, parentNode) {
   return {
     type: ENSURE_FIELDS_INITIALIZED,
-    path
+    fields,
+    parentNode
   };
 }
 

--- a/src/client/components/HealthCareApp.jsx
+++ b/src/client/components/HealthCareApp.jsx
@@ -6,7 +6,6 @@ import IntroductionSection from './IntroductionSection.jsx';
 import Nav from './Nav.jsx';
 import ProgressButton from './ProgressButton';
 import { ensureFieldsInitialized, updateCompletedStatus, updateSubmissionStatus } from '../actions';
-import { pathToData } from '../store';
 
 import * as validations from '../utils/validations';
 
@@ -59,10 +58,11 @@ class HealthCareApp extends React.Component {
 
   handleContinue() {
     const path = this.props.location.pathname;
-    const sectionData = pathToData(this.context.store.getState().veteran, path);
+    const formData = this.context.store.getState().veteran;
+    const sectionFields = this.context.store.getState().uiState.sections[path].fields;
 
-    this.context.store.dispatch(ensureFieldsInitialized(path));
-    if (validations.isValidSection(path, sectionData)) {
+    this.context.store.dispatch(ensureFieldsInitialized(sectionFields));
+    if (validations.isValidSection(path, formData)) {
       hashHistory.push(this.getUrl('next'));
       this.context.store.dispatch(updateCompletedStatus(path));
     }

--- a/src/client/components/Nav.jsx
+++ b/src/client/components/Nav.jsx
@@ -13,7 +13,7 @@ class Nav extends React.Component {
 
   render() {
     const subnavStyles = 'step one wow fadeIn animated';
-    const completedSections = this.props.data.completedSections;
+    const sections = this.props.data.sections;
     const currentUrl = this.props.currentUrl;
 
     function determinePanelStyles(currentPath, completePath) {
@@ -21,7 +21,7 @@ class Nav extends React.Component {
       if (currentUrl.startsWith(currentPath)) {
         classes += ' section-current';
       }
-      if (completedSections[completePath] === true) {
+      if (sections[completePath].complete === true) {
         classes += ' section-complete';
       }
       return classes;

--- a/src/client/components/financial-assessment/AnnualIncomeSection.jsx
+++ b/src/client/components/financial-assessment/AnnualIncomeSection.jsx
@@ -29,7 +29,7 @@ class AnnualIncomeSection extends React.Component {
     let childrenIncomeReview;
     let content;
 
-    if (this.props.receivesVaPension === true) {
+    if (this.props.data.receivesVaPension === true) {
       notRequiredMessage = (
         <p>
           <strong>
@@ -40,22 +40,22 @@ class AnnualIncomeSection extends React.Component {
       );
     }
 
-    if (this.props.childrenData.hasChildrenToReport === true) {
+    if (this.props.data.hasChildrenToReport === true) {
       childrenIncomeInput = (
         <div className="input-section">
           <FixedTable
               component={ChildIncome}
-              onRowsUpdate={(update) => {this.props.onStateChange('children', update);}}
-              relatedData={this.props.childrenData.children}
-              rows={this.props.data.children}/>
+              onRowsUpdate={(update) => {this.props.onStateChange('childrenIncome', update);}}
+              relatedData={this.props.data.children}
+              rows={this.props.data.childrenIncome}/>
         </div>
       );
     }
 
     if (this.props.isSectionComplete && this.props.reviewSection) {
-      const childrenData = this.props.childrenData.children;
+      const childrenData = this.props.data.children;
       let reactKey = 0;
-      childrenIncomeReview = this.props.data.children.map((obj, index) => {
+      childrenIncomeReview = this.props.data.childrenIncome.map((obj, index) => {
         return (
           <div key={reactKey++}>
             <h6>Child: {`${childrenData[index].childFullName.first.value} ${childrenData[index].childFullName.last.value}`}</h6>
@@ -231,17 +231,15 @@ class AnnualIncomeSection extends React.Component {
 
 function mapStateToProps(state) {
   return {
-    data: state.veteran.annualIncome,
-    childrenData: state.veteran.childInformation,
-    receivesVaPension: state.veteran.vaInformation.receivesVaPension,
-    isSectionComplete: state.uiState.completedSections['/financial-assessment/annual-income']
+    data: state.veteran,
+    isSectionComplete: state.uiState.sections['/financial-assessment/annual-income'].complete
   };
 }
 
 function mapDispatchToProps(dispatch) {
   return {
     onStateChange: (field, update) => {
-      dispatch(veteranUpdateField(['annualIncome', field], update));
+      dispatch(veteranUpdateField(field, update));
     },
     initializeChildIncomeFields: () => {
       dispatch(createChildIncomeFields('/financial-assessment/annual-income'));

--- a/src/client/components/financial-assessment/Child.jsx
+++ b/src/client/components/financial-assessment/Child.jsx
@@ -8,7 +8,7 @@ import FullName from '../questions/FullName';
 import SocialSecurityNumber from '../questions/SocialSecurityNumber';
 
 import { childRelationships } from '../../utils/options-for-select.js';
-import { isNotBlank, isValidField, isValidMonetaryValue } from '../../utils/validations';
+import { isNotBlank, isValidField, isValidMonetaryValue, validateIfDirty } from '../../utils/validations';
 
 // TODO: create unique nodes for each child in applicationData
 
@@ -34,7 +34,7 @@ class Child extends React.Component {
           <div className="row">
             <div className="small-12 columns">
               <ErrorableSelect required
-                  errorMessage={isNotBlank(this.props.data.childRelation.value) ? undefined : 'Please select an option'}
+                  errorMessage={validateIfDirty(this.props.data.childRelation, isNotBlank) ? undefined : 'Please select an option'}
                   label="Child’s relationship to you"
                   options={childRelationships}
                   value={this.props.data.childRelation}

--- a/src/client/components/financial-assessment/ChildIncome.jsx
+++ b/src/client/components/financial-assessment/ChildIncome.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import ErrorableTextInput from '../form-elements/ErrorableTextInput';
 
-import { isBlank, isValidMonetaryValue } from '../../utils/validations';
+import { isBlank, isValidMonetaryValue, validateIfDirty } from '../../utils/validations';
 
 /**
  * Sub-component for children income portion AnnualIncomeSection.
@@ -18,21 +18,21 @@ class ChildIncome extends React.Component {
 
     return (
       <div>
-        <h6>Child: {`${this.props.relatedData.childFullName.first} ${this.props.relatedData.childFullName.last}`}</h6>
+        <h6>Child: {`${this.props.relatedData.childFullName.first.value} ${this.props.relatedData.childFullName.last.value}`}</h6>
         <ErrorableTextInput
-            errorMessage={isBlank(this.props.data.childGrossIncome) || isValidMonetaryValue(this.props.data.childGrossIncome) ? undefined : message}
+            errorMessage={validateIfDirty(this.props.data.childGrossIncome, isBlank) || validateIfDirty(this.props.data.childGrossIncome, isValidMonetaryValue) ? undefined : message}
             label="Gross Income"
-            value={this.props.data.childGrossIncome}
+            field={this.props.data.childGrossIncome}
             onValueChange={(update) => {this.props.onValueChange('childGrossIncome', update);}}/>
         <ErrorableTextInput
-            errorMessage={isBlank(this.props.data.childNetIncome) || isValidMonetaryValue(this.props.data.childNetIncome) ? undefined : message}
+            errorMessage={validateIfDirty(this.props.data.childNetIncome, isBlank) || validateIfDirty(this.props.data.childNetIncome, isValidMonetaryValue) ? undefined : message}
             label="Net Income"
-            value={this.props.data.childNetIncome}
+            field={this.props.data.childNetIncome}
             onValueChange={(update) => {this.props.onValueChange('childNetIncome', update);}}/>
         <ErrorableTextInput
-            errorMessage={isBlank(this.props.data.childOtherIncome) || isValidMonetaryValue(this.props.data.childOtherIncome) ? undefined : message}
+            errorMessage={validateIfDirty(this.props.data.childOtherIncome, isBlank) || validateIfDirty(this.props.data.childOtherIncome, isValidMonetaryValue) ? undefined : message}
             label="Other Income"
-            value={this.props.data.childOtherIncome}
+            field={this.props.data.childOtherIncome}
             onValueChange={(update) => {this.props.onValueChange('childOtherIncome', update);}}/>
       </div>
     );

--- a/src/client/components/financial-assessment/ChildInformationSection.jsx
+++ b/src/client/components/financial-assessment/ChildInformationSection.jsx
@@ -47,6 +47,7 @@ class ChildInformationSection extends React.Component {
     let childrenContent;
     let content;
     let children;
+    const fields = ['childFullName', 'childRelation', 'childSocialSecurityNumber', 'childBecameDependent', 'childDateOfBirth', 'childDisabledBefore18', 'childAttendedSchoolLastYear', 'childEducationExpenses', 'childCohabitedLastYear', 'childReceivedSupportLastYear'];
 
     if (this.props.data.children) {
       const childList = this.props.data.children;
@@ -131,7 +132,7 @@ class ChildInformationSection extends React.Component {
               component={Child}
               createRow={this.createBlankChild}
               data={this.props.data}
-              initializeCurrentElement={() => {this.props.initializeFields();}}
+              initializeCurrentElement={() => {this.props.initializeFields(fields);}}
               onRowsUpdate={(update) => {this.props.onStateChange('children', update);}}
               path="/financial-assessment/child-information"
               rows={this.props.data.children}/>
@@ -178,19 +179,18 @@ class ChildInformationSection extends React.Component {
 
 function mapStateToProps(state) {
   return {
-    data: state.veteran.childInformation,
-    receivesVaPension: state.veteran.vaInformation.receivesVaPension,
-    isSectionComplete: state.uiState.completedSections['/financial-assessment/child-information']
+    data: state.veteran,
+    isSectionComplete: state.uiState.sections['/financial-assessment/child-information'].complete
   };
 }
 
 function mapDispatchToProps(dispatch) {
   return {
     onStateChange: (field, update) => {
-      dispatch(veteranUpdateField(['childInformation', field], update));
+      dispatch(veteranUpdateField(field, update));
     },
-    initializeFields: () => {
-      dispatch(ensureFieldsInitialized('/financial-assessment/child-information'));
+    initializeFields: (fields) => {
+      dispatch(ensureFieldsInitialized(fields, 'children'));
     }
   };
 }

--- a/src/client/components/financial-assessment/DeductibleExpensesSection.jsx
+++ b/src/client/components/financial-assessment/DeductibleExpensesSection.jsx
@@ -20,7 +20,7 @@ class DeductibleExpensesSection extends React.Component {
     let notRequiredMessage;
     let content;
 
-    if (this.props.receivesVaPension === true) {
+    if (this.props.data.receivesVaPension === true) {
       notRequiredMessage = (
         <p>
           <strong>
@@ -107,16 +107,15 @@ class DeductibleExpensesSection extends React.Component {
 
 function mapStateToProps(state) {
   return {
-    data: state.veteran.deductibleExpenses,
-    receivesVaPension: state.veteran.vaInformation.receivesVaPension,
-    isSectionComplete: state.uiState.completedSections['/financial-assessment/deductible-expenses']
+    data: state.veteran,
+    isSectionComplete: state.uiState.sections['/financial-assessment/deductible-expenses'].complete
   };
 }
 
 function mapDispatchToProps(dispatch) {
   return {
     onStateChange: (field, update) => {
-      dispatch(veteranUpdateField(['deductibleExpenses', field], update));
+      dispatch(veteranUpdateField(field, update));
     }
   };
 }

--- a/src/client/components/financial-assessment/FinancialDisclosureSection.jsx
+++ b/src/client/components/financial-assessment/FinancialDisclosureSection.jsx
@@ -14,7 +14,7 @@ class FinancialDisclosureSection extends React.Component {
     let notRequiredMessage;
     let content;
 
-    if (this.props.receivesVaPension === true) {
+    if (this.props.data.receivesVaPension === true) {
       notRequiredMessage = (
         <p>
           <strong>
@@ -97,16 +97,15 @@ class FinancialDisclosureSection extends React.Component {
 
 function mapStateToProps(state) {
   return {
-    data: state.veteran.financialDisclosure,
-    receivesVaPension: state.veteran.vaInformation.receivesVaPension,
-    isSectionComplete: state.uiState.completedSections['/financial-assessment/financial-disclosure']
+    data: state.veteran,
+    isSectionComplete: state.uiState.sections['/financial-assessment/financial-disclosure'].complete
   };
 }
 
 function mapDispatchToProps(dispatch) {
   return {
     onStateChange: (field, update) => {
-      dispatch(veteranUpdateField(['financialDisclosure', field], update));
+      dispatch(veteranUpdateField(field, update));
     }
   };
 }

--- a/src/client/components/financial-assessment/SpouseInformationSection.jsx
+++ b/src/client/components/financial-assessment/SpouseInformationSection.jsx
@@ -27,7 +27,7 @@ class SpouseInformationSection extends React.Component {
     let spouseAddressSummary;
     let spouseAddressFields;
 
-    if (this.props.receivesVaPension) {
+    if (this.props.data.receivesVaPension) {
       notRequiredMessage = (
         <p>
           <strong>
@@ -174,7 +174,7 @@ class SpouseInformationSection extends React.Component {
       </fieldset>);
     }
 
-    if (this.props.receivesVaPension === true) {
+    if (this.props.data.receivesVaPension === true) {
       notRequiredMessage = (
         <p>
           <strong>
@@ -206,19 +206,18 @@ class SpouseInformationSection extends React.Component {
 
 function mapStateToProps(state) {
   return {
-    data: state.veteran.spouseInformation,
-    receivesVaPension: state.veteran.vaInformation.receivesVaPension,
+    data: state.veteran,
     neverMarried: calculated.neverMarried(state),
-    isSectionComplete: state.uiState.completedSections['/financial-assessment/spouse-information']
+    isSectionComplete: state.uiState.sections['/financial-assessment/spouse-information'].complete
   };
 }
 
 function mapDispatchToProps(dispatch) {
   return {
     onStateChange: (field, update) => {
-      dispatch(veteranUpdateField(['spouseInformation', field], update));
+      dispatch(veteranUpdateField(field, update));
       if (field === 'sameAddress') {
-        dispatch(updateSpouseAddress(['spouseInformation', 'spouseAddress'], update));
+        dispatch(updateSpouseAddress('spouseAddress', update));
       }
     }
   };

--- a/src/client/components/form-elements/ErrorableRadioButtons.jsx
+++ b/src/client/components/form-elements/ErrorableRadioButtons.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import _ from 'lodash';
 
+import { makeField } from '../../reducers/fields.js';
+
 /**
  * A radio button group with a label.
  *
@@ -23,7 +25,7 @@ class ErrorableRadioButtons extends React.Component {
   }
 
   handleChange(domEvent) {
-    this.props.onValueChange(domEvent.target.value);
+    this.props.onValueChange(makeField(domEvent.target.value, true));
   }
 
   render() {
@@ -43,7 +45,7 @@ class ErrorableRadioButtons extends React.Component {
     }
 
     const options = _.isArray(this.props.options) ? this.props.options : [];
-    const storedValue = this.props.value;
+    const storedValue = this.props.value.value;
     let reactKey = 0;
     const optionElements = options.map((obj, index) => {
       let optionLabel;

--- a/src/client/components/form-elements/ReviewCollapsiblePanel.jsx
+++ b/src/client/components/form-elements/ReviewCollapsiblePanel.jsx
@@ -40,8 +40,8 @@ class ReviewCollapsiblePanel extends React.Component {
     let editButton;
     let verifiedLabel;
     const currentPath = this.props.updatePath;
-    const sectionsComplete = this.props.uiData.completedSections[currentPath];
-    const sectionsVerified = this.props.uiData.verifiedSections[currentPath];
+    const sectionsComplete = this.props.uiData.sections[currentPath].complete;
+    const sectionsVerified = this.props.uiData.sections[currentPath].verified;
 
 
     if (sectionsComplete) {

--- a/src/client/components/insurance-information/InsuranceInformationSection.jsx
+++ b/src/client/components/insurance-information/InsuranceInformationSection.jsx
@@ -18,12 +18,6 @@ class InsuranceInformationSection extends React.Component {
   createBlankProvider() {
     return {
       insuranceName: makeField(''),
-      insuranceAddress: makeField(''),
-      insuranceCity: makeField(''),
-      insuranceCountry: makeField(''),
-      insuranceState: makeField(''),
-      insuranceZipcode: makeField(''),
-      insurancePhone: makeField(''),
       insurancePolicyHolderName: makeField(''),
       insurancePolicyNumber: makeField(''),
       insuranceGroupCode: makeField(''),
@@ -34,6 +28,7 @@ class InsuranceInformationSection extends React.Component {
     let providersTable;
     let content;
     let providers;
+    const fields = ['insuranceName', 'insurancePolicyHolderName', 'insurancePolicyNumber', 'insuranceGroupCode'];
 
     if (this.props.data.isCoveredByHealthInsurance) {
       providersTable = (
@@ -41,7 +36,7 @@ class InsuranceInformationSection extends React.Component {
             component={Provider}
             createRow={this.createBlankProvider}
             data={this.props.data}
-            initializeCurrentElement={() => {this.props.initializeFields();}}
+            initializeCurrentElement={() => {this.props.initializeFields(fields);}}
             onRowsUpdate={(update) => {this.props.onStateChange('providers', update);}}
             path="/insurance-information/general"
             rows={this.props.data.providers}/>
@@ -55,12 +50,6 @@ class InsuranceInformationSection extends React.Component {
       let providerIndex = 0;
       providers = providersList.map((obj) => {
         const insuranceName = obj.insuranceName.value;
-        const insuranceAddress = obj.insuranceAddress.value;
-        const insuranceCity = obj.insuranceCity.value;
-        const insuranceCountry = obj.insuranceCountry.value;
-        const insuranceState = obj.insuranceState.value;
-        const insuranceZipcode = obj.insuranceZipcode.value;
-        const insurancePhone = obj.insurancePhone.value;
         const insurancePolicyHolderName = obj.insurancePolicyHolderName.value;
         const insurancePolicyNumber = obj.insurancePolicyNumber.value;
         const insuranceGroupCode = obj.insuranceGroupCode.value;
@@ -75,30 +64,6 @@ class InsuranceInformationSection extends React.Component {
             <tr>
               <td>Name:</td>
               <td>{insuranceName}</td>
-            </tr>
-            <tr>
-              <td>Address:</td>
-              <td>{insuranceAddress}</td>
-            </tr>
-            <tr>
-              <td>City:</td>
-              <td>{insuranceCity}</td>
-            </tr>
-            <tr>
-              <td>Country:</td>
-              <td>{insuranceCountry}</td>
-            </tr>
-            <tr>
-              <td>State:</td>
-              <td>{insuranceState}</td>
-            </tr>
-            <tr>
-              <td>ZIP Code:</td>
-              <td>{insuranceZipcode}</td>
-            </tr>
-            <tr>
-              <td>Phone:</td>
-              <td>{insurancePhone}</td>
             </tr>
             <tr>
               <td>Policy Holder Name:</td>
@@ -151,18 +116,18 @@ class InsuranceInformationSection extends React.Component {
 
 function mapStateToProps(state) {
   return {
-    data: state.veteran.insuranceInformation,
-    isSectionComplete: state.uiState.completedSections['/insurance-information/general']
+    data: state.veteran,
+    isSectionComplete: state.uiState.sections['/insurance-information/general'].complete
   };
 }
 
 function mapDispatchToProps(dispatch) {
   return {
     onStateChange: (field, update) => {
-      dispatch(veteranUpdateField(['insuranceInformation', field], update));
+      dispatch(veteranUpdateField(field, update));
     },
-    initializeFields: () => {
-      dispatch(ensureFieldsInitialized('/insurance-information/general'));
+    initializeFields: (fields) => {
+      dispatch(ensureFieldsInitialized(fields, 'providers'));
     }
   };
 }

--- a/src/client/components/insurance-information/MedicareMedicaidSection.jsx
+++ b/src/client/components/insurance-information/MedicareMedicaidSection.jsx
@@ -74,15 +74,15 @@ class MedicareMedicaidSection extends React.Component {
 
 function mapStateToProps(state) {
   return {
-    data: state.veteran.medicareMedicaid,
-    isSectionComplete: state.uiState.completedSections['/insurance-information/medicare-medicaid']
+    data: state.veteran,
+    isSectionComplete: state.uiState.sections['/insurance-information/medicare-medicaid'].complete
   };
 }
 
 function mapDispatchToProps(dispatch) {
   return {
     onStateChange: (field, update) => {
-      dispatch(veteranUpdateField(['medicareMedicaid', field], update));
+      dispatch(veteranUpdateField(field, update));
     }
   };
 }

--- a/src/client/components/military-service/AdditionalMilitaryInformationSection.jsx
+++ b/src/client/components/military-service/AdditionalMilitaryInformationSection.jsx
@@ -117,15 +117,15 @@ class AdditionalMilitaryInformationSection extends React.Component {
 
 function mapStateToProps(state) {
   return {
-    data: state.veteran.militaryAdditionalInfo,
-    isSectionComplete: state.uiState.completedSections['/military-service/additional-information']
+    data: state.veteran,
+    isSectionComplete: state.uiState.sections['/military-service/additional-information'].complete
   };
 }
 
 function mapDispatchToProps(dispatch) {
   return {
     onStateChange: (field, update) => {
-      dispatch(veteranUpdateField(['militaryAdditionalInfo', field], update));
+      dispatch(veteranUpdateField(field, update));
     }
   };
 }

--- a/src/client/components/military-service/ServiceInformationSection.jsx
+++ b/src/client/components/military-service/ServiceInformationSection.jsx
@@ -79,15 +79,15 @@ class ServiceInformationSection extends React.Component {
 
 function mapStateToProps(state) {
   return {
-    data: state.veteran.serviceInformation,
-    isSectionComplete: state.uiState.completedSections['/military-service/service-information']
+    data: state.veteran,
+    isSectionComplete: state.uiState.sections['/military-service/service-information'].complete
   };
 }
 
 function mapDispatchToProps(dispatch) {
   return {
     onStateChange: (field, update) => {
-      dispatch(veteranUpdateField(['serviceInformation', field], update));
+      dispatch(veteranUpdateField(field, update));
     }
   };
 }

--- a/src/client/components/personal-information/AdditionalInformationSection.jsx
+++ b/src/client/components/personal-information/AdditionalInformationSection.jsx
@@ -80,15 +80,15 @@ class AdditionalInformationSection extends React.Component {
 
 function mapStateToProps(state) {
   return {
-    data: state.veteran.additionalInformation,
-    isSectionComplete: state.uiState.completedSections['/personal-information/additional-information']
+    data: state.veteran,
+    isSectionComplete: state.uiState.sections['/personal-information/additional-information'].complete
   };
 }
 
 function mapDispatchToProps(dispatch) {
   return {
     onStateChange: (field, update) => {
-      dispatch(veteranUpdateField(['additionalInformation', field], update));
+      dispatch(veteranUpdateField(field, update));
     }
   };
 }

--- a/src/client/components/personal-information/DemographicInformationSection.jsx
+++ b/src/client/components/personal-information/DemographicInformationSection.jsx
@@ -100,15 +100,15 @@ class DemographicInformationSection extends React.Component {
 
 function mapStateToProps(state) {
   return {
-    data: state.veteran.demographicInformation,
-    isSectionComplete: state.uiState.completedSections['/personal-information/demographic-information']
+    data: state.veteran,
+    isSectionComplete: state.uiState.sections['/personal-information/demographic-information'].complete
   };
 }
 
 function mapDispatchToProps(dispatch) {
   return {
     onStateChange: (field, update) => {
-      dispatch(veteranUpdateField(['demographicInformation', field], update));
+      dispatch(veteranUpdateField(field, update));
     }
   };
 }

--- a/src/client/components/personal-information/NameAndGeneralInfoSection.jsx
+++ b/src/client/components/personal-information/NameAndGeneralInfoSection.jsx
@@ -26,7 +26,7 @@ class NameAndGeneralInfoSection extends React.Component {
         <tbody>
           <tr>
             <td>Veteran Name:</td>
-            <td>{this.props.data.fullName.first.value} {this.props.data.fullName.middle.value} {this.props.data.fullName.last.value} {this.props.data.fullName.suffix.value}</td>
+            <td>{this.props.data.veteranFullName.first.value} {this.props.data.veteranFullName.middle.value} {this.props.data.veteranFullName.last.value} {this.props.data.veteranFullName.suffix.value}</td>
           </tr>
           <tr>
             <td>Mother's Maiden Name:</td>
@@ -34,7 +34,7 @@ class NameAndGeneralInfoSection extends React.Component {
           </tr>
           <tr>
             <td>Social Security Number:</td>
-            <td>{this.props.data.socialSecurityNumber.value}</td>
+            <td>{this.props.data.veteranSocialSecurityNumber.value}</td>
           </tr>
           <tr>
             <td>Gender:</td>
@@ -42,7 +42,7 @@ class NameAndGeneralInfoSection extends React.Component {
           </tr>
           <tr>
             <td>Date of Birth:</td>
-            <td>{this.props.data.dateOfBirth.month.value}/{this.props.data.dateOfBirth.day.value}/{this.props.data.dateOfBirth.year.value}</td>
+            <td>{this.props.data.veteranDateOfBirth.month.value}/{this.props.data.veteranDateOfBirth.day.value}/{this.props.data.veteranDateOfBirth.year.value}</td>
           </tr>
           <tr>
             <td>Place of Birth:</td>
@@ -60,21 +60,21 @@ class NameAndGeneralInfoSection extends React.Component {
         <p>(<span className="hca-required-span">*</span>) Indicates a required field</p>
         <div className="input-section">
           <FullName required
-              name={this.props.data.fullName}
-              onUserInput={(update) => {this.props.onStateChange('fullName', update);}}/>
+              name={this.props.data.veteranFullName}
+              onUserInput={(update) => {this.props.onStateChange('veteranFullName', update);}}/>
           <MothersMaidenName value={this.props.data.mothersMaidenName}
               onUserInput={(update) => {this.props.onStateChange('mothersMaidenName', update);}}/>
           <SocialSecurityNumber required
-              ssn={this.props.data.socialSecurityNumber}
-              onValueChange={(update) => {this.props.onStateChange('socialSecurityNumber', update);}}/>
+              ssn={this.props.data.veteranSocialSecurityNumber}
+              onValueChange={(update) => {this.props.onStateChange('veteranSocialSecurityNumber', update);}}/>
           <Gender required
               value={this.props.data.gender}
               onUserInput={(update) => {this.props.onStateChange('gender', update);}}/>
           <DateInput required
-              day={this.props.data.dateOfBirth.day}
-              month={this.props.data.dateOfBirth.month}
-              year={this.props.data.dateOfBirth.year}
-              onValueChange={(update) => {this.props.onStateChange('dateOfBirth', update);}}/>
+              day={this.props.data.veteranDateOfBirth.day}
+              month={this.props.data.veteranDateOfBirth.month}
+              year={this.props.data.veteranDateOfBirth.year}
+              onValueChange={(update) => {this.props.onStateChange('veteranDateOfBirth', update);}}/>
         </div>
         <div className="input-section">
           <h4>Place of Birth</h4>
@@ -106,15 +106,15 @@ class NameAndGeneralInfoSection extends React.Component {
 
 function mapStateToProps(state) {
   return {
-    data: state.veteran.nameAndGeneralInformation,
-    isSectionComplete: state.uiState.completedSections['/personal-information/name-and-general-information']
+    data: state.veteran,
+    isSectionComplete: state.uiState.sections['/personal-information/name-and-general-information'].complete
   };
 }
 
 function mapDispatchToProps(dispatch) {
   return {
     onStateChange: (field, update) => {
-      dispatch(veteranUpdateField(['nameAndGeneralInformation', field], update));
+      dispatch(veteranUpdateField(field, update));
     }
   };
 }

--- a/src/client/components/personal-information/VAInformationSection.jsx
+++ b/src/client/components/personal-information/VAInformationSection.jsx
@@ -83,16 +83,15 @@ class VaInformationSection extends React.Component {
 
 function mapStateToProps(state) {
   return {
-    data: state.veteran.vaInformation,
-    isSectionComplete: state.uiState.completedSections['/personal-information/va-information']
+    data: state.veteran,
+    isSectionComplete: state.uiState.sections['/personal-information/va-information'].complete
   };
 }
 
 function mapDispatchToProps(dispatch) {
   return {
     onStateChange: (field, update) => {
-      // TODO: Updates for radio buttons are getting passed as a string instead of makeField();
-      dispatch(veteranUpdateField(['vaInformation', field], update));
+      dispatch(veteranUpdateField(field, update));
     }
   };
 }

--- a/src/client/components/personal-information/VeteranAddressSection.jsx
+++ b/src/client/components/personal-information/VeteranAddressSection.jsx
@@ -34,27 +34,27 @@ class VeteranAddressSection extends React.Component {
         <tbody>
           <tr>
             <td>Street:</td>
-            <td>{this.props.data.address.street.value}</td>
+            <td>{this.props.data.veteranAddress.street.value}</td>
           </tr>
           <tr>
             <td>City:</td>
-            <td>{this.props.data.address.city.value}</td>
+            <td>{this.props.data.veteranAddress.city.value}</td>
           </tr>
           <tr>
             <td>Country:</td>
-            <td>{this.props.data.address.country.value}</td>
+            <td>{this.props.data.veteranAddress.country.value}</td>
           </tr>
           <tr>
             <td>State:</td>
-            <td>{this.props.data.address.state.value}</td>
+            <td>{this.props.data.veteranAddress.state.value}</td>
           </tr>
           <tr>
             <td>ZIP Code:</td>
-            <td>{this.props.data.address.zipcode.value}</td>
+            <td>{this.props.data.veteranAddress.zipcode.value}</td>
           </tr>
           <tr>
             <td>County:</td>
-            <td>{this.props.data.county.value}</td>
+            <td>{this.props.data.veteranCounty.value}</td>
           </tr>
           <tr>
             <td>Email Address:</td>
@@ -82,12 +82,12 @@ class VeteranAddressSection extends React.Component {
               (e.g., "Paris,France"), and select Foreign Country for State.
           </p>
 
-          <Address value={this.props.data.address}
-              onUserInput={(update) => {this.props.onStateChange('address', update);}}/>
+          <Address value={this.props.data.veteranAddress}
+              onUserInput={(update) => {this.props.onStateChange('veteranAddress', update);}}/>
 
           <ErrorableTextInput label="County"
-              field={this.props.data.county}
-              onValueChange={(update) => {this.props.onStateChange('county', update);}}/>
+              field={this.props.data.veteranCounty}
+              onValueChange={(update) => {this.props.onStateChange('veteranCounty', update);}}/>
 
           <Email label="Email address"
               email={this.props.data.email}
@@ -121,15 +121,15 @@ class VeteranAddressSection extends React.Component {
 
 function mapStateToProps(state) {
   return {
-    data: state.veteran.veteranAddress,
-    isSectionComplete: state.uiState.completedSections['/personal-information/veteran-address']
+    data: state.veteran,
+    isSectionComplete: state.uiState.sections['/personal-information/veteran-address'].complete
   };
 }
 
 function mapDispatchToProps(dispatch) {
   return {
     onStateChange: (field, update) => {
-      dispatch(veteranUpdateField(['veteranAddress', field], update));
+      dispatch(veteranUpdateField(field, update));
     }
   };
 }

--- a/src/client/reducers/uiState/index.js
+++ b/src/client/reducers/uiState/index.js
@@ -9,42 +9,88 @@ _.mixin(lodashDeep);
 
 const ui = {
   applicationSubmitted: false,
-  completedSections: {
-    '/introduction': false,
-    '/personal-information/name-and-general-information': false,
-    '/personal-information/va-information': false,
-    '/personal-information/additional-information': false,
-    '/personal-information/demographic-information': false,
-    '/personal-information/veteran-address': false,
-    '/insurance-information/general': false,
-    '/insurance-information/medicare-medicaid': false,
-    '/military-service/service-information': false,
-    '/military-service/additional-information': false,
-    '/financial-assessment/financial-disclosure': false,
-    '/financial-assessment/spouse-information': false,
-    '/financial-assessment/child-information': false,
-    '/financial-assessment/annual-income': false,
-    '/financial-assessment/deductible-expenses': false,
-    '/review-and-submit': false
-  },
-  verifiedSections: {
-    '/introduction': false,
-    '/personal-information/name-and-general-information': false,
-    '/personal-information/va-information': false,
-    '/personal-information/additional-information': false,
-    '/personal-information/demographic-information': false,
-    '/personal-information/veteran-address': false,
-    '/insurance-information/general': false,
-    '/insurance-information/medicare-medicaid': false,
-    '/military-service/service-information': false,
-    '/military-service/additional-information': false,
-    '/financial-assessment/financial-disclosure': false,
-    '/financial-assessment/spouse-information': false,
-    '/financial-assessment/child-information': false,
-    '/financial-assessment/annual-income': false,
-    '/financial-assessment/deductible-expenses': false,
-    '/review-and-submit': false
-  },
+  sections: {
+    '/introduction': {
+      complete: false,
+      verified: false,
+      fields: []
+    },
+    '/personal-information/name-and-general-information': {
+      complete: false,
+      verified: false,
+      fields: ['veteranFullName', 'mothersMaidenName', 'veteranSocialSecurityNumber', 'gender', 'cityOfBirth', 'stateOfBirth', 'veteranDateOfBirth', 'maritalStatus']
+    },
+    '/personal-information/va-information': {
+      complete: false,
+      verified: false,
+      fields: ['isVaServiceConnected', 'compensableVaServiceConnected', 'receivesVaPension']
+    },
+    '/personal-information/additional-information': {
+      complete: false,
+      verified: false,
+      fields: ['isEssentialAcaCoverage', 'facilityState', 'vaMedicalFacility', 'wantsInitialVaContact']
+    },
+    '/personal-information/demographic-information': {
+      complete: false,
+      verified: false,
+      fields: ['isSpanishHispanicLatino', 'isAmericanIndianOrAlaskanNative', 'isBlackOrAfricanAmerican', 'isNativeHawaiianOrOtherPacificIslander', 'isAsian', 'isWhite']
+    },
+    '/personal-information/veteran-address': {
+      complete: false,
+      verified: false,
+      fields: ['veteranAddress', 'veteranCounty', 'email', 'emailConfirmation', 'homePhone', 'mobilePhone']
+    },
+    '/insurance-information/general': {
+      complete: false,
+      verified: false,
+      fields: ['isCoveredByHealthInsurance', 'providers']
+    },
+    '/insurance-information/medicare-medicaid': {
+      complete: false,
+      verified: false,
+      fields: ['isMedicaidEligible', 'isEnrolledMedicarePartA', 'medicarePartAEffectiveDate']
+    },
+    '/military-service/service-information': {
+      complete: false,
+      verified: false,
+      fields: ['lastServiceBranch', 'lastEntryDate', 'lastDischargeDate', 'dischargeType']
+    },
+    '/military-service/additional-information': {
+      complete: false,
+      verified: false,
+      fields: ['purpleHeartRecipient', 'isFormerPow', 'postNov111998Combat', 'disabledInLineOfDuty', 'swAsiaCombat', 'vietnamService', 'exposedToRadiation', 'radiumTreatments', 'campLejeune']
+    },
+    '/financial-assessment/financial-disclosure': {
+      complete: false,
+      verified: false,
+      fields: ['provideFinancialInfo', 'understandsFinancialDisclosure']
+    },
+    '/financial-assessment/spouse-information': {
+      completed: false,
+      verified: false,
+      fields: ['spouseFullName', 'spouseSocialSecurityNumber', 'spouseDateOfBirth', 'dateOfMarriage', 'sameAddress', 'cohabitedLastYear', 'provideSupportLastYear', 'spouseAddress', 'spousePhone']
+    },
+    '/financial-assessment/child-information': {
+      complete: false,
+      verified: false,
+      fields: ['hasChildrenToReport', 'children']
+    },
+    '/financial-assessment/annual-income': {
+      complete: false,
+      verified: false,
+      fields: ['veteranGrossIncome', 'veteranNetIncome', 'veteranOtherIncome', 'spouseGrossIncome', 'spouseNetIncome', 'spouseOtherIncome', 'childrenIncome']
+    },
+    '/financial-assessment/deductible-expenses': {
+      complete: false,
+      verified: false,
+      fields: ['deductibleMedicalExpenses', 'deductibleFuneralExpenses', 'deductibleEducationExpenses']
+    },
+    '/review-and-submit': {
+      complete: false,
+      verified: false,
+      fields: []
+    }
+  }
 };
 
 function uiState(state = ui, action) {
@@ -52,22 +98,22 @@ function uiState(state = ui, action) {
   switch (action.type) {
     case UPDATE_COMPLETED_STATUS:
       newState = Object.assign({}, state);
-      _.set(newState.completedSections, action.path, true);
+      _.set(newState.sections, [action.path, 'complete'], true);
       return newState;
 
     case UPDATE_INCOMPLETE_STATUS:
       newState = Object.assign({}, state);
-      _.set(newState.completedSections, action.path, false);
+      _.set(newState.sections, [action.path, 'complete'], false);
       return newState;
 
     case UPDATE_REVIEW_STATUS:
       newState = Object.assign({}, state);
-      _.set(newState.completedSections, action.path, action.value);
+      _.set(newState.sections, [action.path, 'complete'], action.value);
       return newState;
 
     case UPDATE_VERIFIED_STATUS:
       newState = Object.assign({}, state);
-      _.set(newState.verifiedSections, action.path, action.value);
+      _.set(newState.sections, [action.path, 'verified'], action.value);
       return newState;
 
     case UPDATE_SUBMISSION_STATUS:

--- a/src/client/reducers/veteran/index.js
+++ b/src/client/reducers/veteran/index.js
@@ -3,171 +3,140 @@ import lodashDeep from 'lodash-deep';
 
 import { ENSURE_FIELDS_INITIALIZED, VETERAN_FIELD_UPDATE, UPDATE_SPOUSE_ADDRESS, CREATE_CHILD_INCOME_FIELDS } from '../../actions';
 import { makeField, dirtyAllFields } from '../fields';
-import { pathToData } from '../../store';
 
 // Add deep object manipulation routines to lodash.
 _.mixin(lodashDeep);
 
-// TODO(awong): This structure should reflect a logical data model for a veteran. Currently it
-// mirrors the UI stricture too much.
-
 // TODO: Remove providers and children if checkbox within section is unchecked
 const blankVeteran = {
-  nameAndGeneralInformation: {
-    fullName: {
-      first: makeField(''),
-      middle: makeField(''),
-      last: makeField(''),
-      suffix: makeField(''),
-    },
-    mothersMaidenName: makeField(''),
-    socialSecurityNumber: makeField(''),
-    gender: makeField(''),
-    cityOfBirth: makeField(''),
-    stateOfBirth: makeField(''),
-    dateOfBirth: {
-      month: makeField(''),
-      day: makeField(''),
-      year: makeField(''),
-    },
-    maritalStatus: makeField('')
+  veteranFullName: {
+    first: makeField(''),
+    middle: makeField(''),
+    last: makeField(''),
+    suffix: makeField(''),
   },
+  mothersMaidenName: makeField(''),
+  veteranSocialSecurityNumber: makeField(''),
+  gender: makeField(''),
+  cityOfBirth: makeField(''),
+  stateOfBirth: makeField(''),
+  veteranDateOfBirth: {
+    month: makeField(''),
+    day: makeField(''),
+    year: makeField(''),
+  },
+  maritalStatus: makeField(''),
 
-  vaInformation: {
-    isVaServiceConnected: makeField(''),
-    compensableVaServiceConnected: makeField(''),
-    receivesVaPension: makeField('')
-  },
+  isVaServiceConnected: makeField(''),
+  compensableVaServiceConnected: makeField(''),
+  receivesVaPension: makeField(''),
 
-  additionalInformation: {
-    isEssentialAcaCoverage: false,
-    facilityState: makeField(''),
-    vaMedicalFacility: makeField(''),
-    wantsInitialVaContact: false
-  },
+  isEssentialAcaCoverage: false,
+  facilityState: makeField(''),
+  vaMedicalFacility: makeField(''),
+  wantsInitialVaContact: false,
 
-  demographicInformation: {
-    isSpanishHispanicLatino: false,
-    isAmericanIndianOrAlaskanNative: false,
-    isBlackOrAfricanAmerican: false,
-    isNativeHawaiianOrOtherPacificIslander: false,
-    isAsian: false,
-    isWhite: false
-  },
+  isSpanishHispanicLatino: false,
+  isAmericanIndianOrAlaskanNative: false,
+  isBlackOrAfricanAmerican: false,
+  isNativeHawaiianOrOtherPacificIslander: false,
+  isAsian: false,
+  isWhite: false,
 
   veteranAddress: {
-    address: {
-      street: makeField(''),
-      city: makeField(''),
-      country: makeField(''),
-      state: makeField(''),
-      zipcode: makeField(''),
-    },
-    county: makeField(''),
-    email: makeField(''),
-    emailConfirmation: makeField(''),
-    homePhone: makeField(''),
-    mobilePhone: makeField('')
+    street: makeField(''),
+    city: makeField(''),
+    country: makeField(''),
+    state: makeField(''),
+    zipcode: makeField(''),
+  },
+  veteranCounty: makeField(''),
+  email: makeField(''),
+  emailConfirmation: makeField(''),
+  homePhone: makeField(''),
+  mobilePhone: makeField(''),
+
+  provideFinancialInfo: false,
+  understandsFinancialDisclosure: false,
+
+  spouseFullName: {
+    first: makeField(''),
+    middle: makeField(''),
+    last: makeField(''),
+    suffix: makeField(''),
+  },
+  spouseSocialSecurityNumber: makeField(''),
+  spouseDateOfBirth: {
+    month: makeField(''),
+    day: makeField(''),
+    year: makeField(''),
+  },
+  dateOfMarriage: {
+    month: makeField(''),
+    day: makeField(''),
+    year: makeField('')
+  },
+  sameAddress: false,
+  cohabitedLastYear: false,
+  provideSupportLastYear: false,
+  spouseAddress: {
+    street: makeField(''),
+    city: makeField(''),
+    country: makeField(''),
+    state: makeField(''),
+    zipcode: makeField(''),
+  },
+  spousePhone: makeField(''),
+
+  hasChildrenToReport: false,
+  children: [],
+
+  veteranGrossIncome: makeField(''),
+  veteranNetIncome: makeField(''),
+  veteranOtherIncome: makeField(''),
+  spouseGrossIncome: makeField(''),
+  spouseNetIncome: makeField(''),
+  spouseOtherIncome: makeField(''),
+  childrenIncome: [],
+
+  deductibleMedicalExpenses: makeField(''),
+  deductibleFuneralExpenses: makeField(''),
+  deductibleEducationExpenses: makeField(''),
+
+  isCoveredByHealthInsurance: false,
+  providers: [],
+
+  isMedicaidEligible: false,
+  isEnrolledMedicarePartA: false,
+  medicarePartAEffectiveDate: {
+    month: makeField(''),
+    day: makeField(''),
+    year: makeField('')
   },
 
-  financialDisclosure: {
-    provideFinancialInfo: false,
-    understandsFinancialDisclosure: false
+  lastServiceBranch: makeField(''),
+  lastEntryDate: {
+    month: makeField(''),
+    day: makeField(''),
+    year: makeField('')
   },
-
-  spouseInformation: {
-    spouseFullName: {
-      first: makeField(''),
-      middle: makeField(''),
-      last: makeField(''),
-      suffix: makeField(''),
-    },
-    spouseSocialSecurityNumber: makeField(''),
-    spouseDateOfBirth: {
-      month: makeField(''),
-      day: makeField(''),
-      year: makeField(''),
-    },
-    dateOfMarriage: {
-      month: makeField(''),
-      day: makeField(''),
-      year: makeField('')
-    },
-    sameAddress: false,
-    cohabitedLastYear: false,
-    provideSupportLastYear: false,
-    spouseAddress: {
-      street: makeField(''),
-      city: makeField(''),
-      country: makeField(''),
-      state: makeField(''),
-      zipcode: makeField(''),
-    },
-    spousePhone: makeField('')
+  lastDischargeDate: {
+    month: makeField(''),
+    day: makeField(''),
+    year: makeField('')
   },
+  dischargeType: makeField(''),
 
-  childInformation: {
-    hasChildrenToReport: false,
-    children: []
-  },
+  purpleHeartRecipient: false,
+  isFormerPow: false,
+  postNov111998Combat: false,
+  disabledInLineOfDuty: false,
+  swAsiaCombat: false,
+  vietnamService: false,
+  exposedToRadiation: false,
+  radiumTreatments: false,
+  campLejeune: false
 
-  annualIncome: {
-    veteranGrossIncome: makeField(''),
-    veteranNetIncome: makeField(''),
-    veteranOtherIncome: makeField(''),
-    spouseGrossIncome: makeField(''),
-    spouseNetIncome: makeField(''),
-    spouseOtherIncome: makeField(''),
-    children: []
-  },
-
-  deductibleExpenses: {
-    deductibleMedicalExpenses: makeField(''),
-    deductibleFuneralExpenses: makeField(''),
-    deductibleEducationExpenses: makeField('')
-  },
-
-  insuranceInformation: {
-    isCoveredByHealthInsurance: false,
-    providers: []
-  },
-
-  medicareMedicaid: {
-    isMedicaidEligible: false,
-    isEnrolledMedicarePartA: false,
-    medicarePartAEffectiveDate: {
-      month: makeField(''),
-      day: makeField(''),
-      year: makeField('')
-    }
-  },
-
-  serviceInformation: {
-    lastServiceBranch: makeField(''),
-    lastEntryDate: {
-      month: makeField(''),
-      day: makeField(''),
-      year: makeField('')
-    },
-    lastDischargeDate: {
-      month: makeField(''),
-      day: makeField(''),
-      year: makeField('')
-    },
-    dischargeType: makeField('')
-  },
-
-  militaryAdditionalInfo: {
-    purpleHeartRecipient: false,
-    isFormerPow: false,
-    postNov111998Combat: false,
-    disabledInLineOfDuty: false,
-    swAsiaCombat: false,
-    vietnamService: false,
-    exposedToRadiation: false,
-    radiumTreatments: false,
-    campLejeune: false
-  }
 };
 
 function createBlankChild() {
@@ -189,9 +158,19 @@ function veteran(state = blankVeteran, action) {
 
     case ENSURE_FIELDS_INITIALIZED: {
       newState = Object.assign({}, state);
-      // TODO(awong): HACK! Assigning to the sub object assumes pathToData() returns a reference
-      // to the actual substructre such that it can be reassigned to.
-      Object.assign(pathToData(newState, action.path), dirtyAllFields(pathToData(newState, action.path)));
+
+      if (action.parentNode) {
+        action.fields.map((field) => {
+          Object.assign(newState[action.parentNode][0][field], dirtyAllFields(newState[action.parentNode][0][field]));
+          return newState;
+        });
+      } else {
+        action.fields.map((field) => {
+          Object.assign(newState[field], dirtyAllFields(newState[field]));
+          return newState;
+        });
+      }
+
       return newState;
     }
 
@@ -217,13 +196,14 @@ function veteran(state = blankVeteran, action) {
     case CREATE_CHILD_INCOME_FIELDS:
       newState = Object.assign({}, state);
       // update children income from children info
-      newState.annualIncome.children.splice(newState.childInformation.children.length);
-      for (let i = 0; i < newState.childInformation.children.length; i++) {
-        if (newState.annualIncome.children[i] === undefined) {
-          newState.annualIncome.children[i] = createBlankChild();
+      newState.childrenIncome.splice(newState.children.length);
+      for (let i = 0; i < newState.children.length; i++) {
+        if (newState.childrenIncome[i] === undefined) {
+          newState.childrenIncome[i] = createBlankChild();
         }
       }
-      Object.assign(pathToData(newState, action.path), dirtyAllFields(pathToData(newState, action.path)));
+
+      Object.assign(newState.childrenIncome, dirtyAllFields(newState.childrenIncome));
       return newState;
 
     default:

--- a/src/client/store/calculated.js
+++ b/src/client/store/calculated.js
@@ -2,6 +2,6 @@
 //
 
 export function neverMarried(state) {
-  return state.veteran.nameAndGeneralInformation.maritalStatus === '' ||
-    state.veteran.nameAndGeneralInformation.maritalStatus === 'Never Married';
+  return state.veteran.maritalStatus === '' ||
+    state.veteran.maritalStatus === 'Never Married';
 }

--- a/src/client/utils/validations.js
+++ b/src/client/utils/validations.js
@@ -215,15 +215,15 @@ function isValidChildren(data) {
 }
 
 function isValidChildrenIncome(data) {
-  const children = data.children;
+  const children = data.childrenIncome;
   if (children.length === 0) {
     return true;
   }
   for (let i = 0; i < children.length; i++) {
     if (
-        !isValidField(isValidMonetaryValue, children[i].childrenGrossIncome) &&
-        !isValidField(isValidMonetaryValue, children[i].childrenNetIncome) &&
-        !isValidField(isValidMonetaryValue, children[i].childrenOtherIncome)
+        !isValidField(isValidMonetaryValue, children[i].childGrossIncome) &&
+        !isValidField(isValidMonetaryValue, children[i].childNetIncome) &&
+        !isValidField(isValidMonetaryValue, children[i].childOtherIncome)
     ) {
       return false;
     }

--- a/test/client/components/form-elements/ErrorableRadioButtons.spec.jsx
+++ b/test/client/components/form-elements/ErrorableRadioButtons.spec.jsx
@@ -5,6 +5,7 @@ import sinon from 'sinon';
 import { expect } from 'chai';
 
 import ErrorableRadioButtons from '../../../../src/client/components/form-elements/ErrorableRadioButtons';
+import { makeField } from '../../../../src/client/reducers/fields';
 
 describe('<ErrorableRadioButtons>', () => {
   const options = [{ value: 'yes', label: 'Yes' }, { value: 'no', label: 'No' }];
@@ -21,35 +22,35 @@ describe('<ErrorableRadioButtons>', () => {
 
     it('label is required', () => {
       SkinDeep.shallowRender(
-        <ErrorableRadioButtons options={options} onValueChange={(_update) => {}}/>);
+        <ErrorableRadioButtons options={options} value={makeField('test')} onValueChange={(_update) => {}}/>);
       sinon.assert.calledWithMatch(consoleStub, /Required prop `label` was not specified in `ErrorableRadioButtons`/);
     });
 
     it('label must be a string', () => {
       SkinDeep.shallowRender(
-        <ErrorableRadioButtons label options={options} onValueChange={(_update) => {}}/>);
+        <ErrorableRadioButtons label options={options} value={makeField('test')} onValueChange={(_update) => {}}/>);
       sinon.assert.calledWithMatch(consoleStub, /Invalid prop `label` of type `boolean` supplied to `ErrorableRadioButtons`, expected `string`./);
     });
 
     it('onValueChange is required', () => {
-      SkinDeep.shallowRender(<ErrorableRadioButtons label="test" options={options}/>);
+      SkinDeep.shallowRender(<ErrorableRadioButtons label="test" value={makeField('test')} options={options}/>);
       sinon.assert.calledWithMatch(consoleStub, /Required prop `onValueChange` was not specified in `ErrorableRadioButtons`/);
     });
 
     it('onValueChange must be a function', () => {
-      SkinDeep.shallowRender(<ErrorableRadioButtons label="test" options={options} onValueChange/>);
+      SkinDeep.shallowRender(<ErrorableRadioButtons label="test" options={options} value={makeField('test')} onValueChange/>);
       sinon.assert.calledWithMatch(consoleStub, /Invalid prop `onValueChange` of type `boolean` supplied to `ErrorableRadioButtons`, expected `function`/);
     });
 
     it('options is required', () => {
       SkinDeep.shallowRender(
-        <ErrorableRadioButtons label="test" onValueChange={(_update) => {}}/>);
+        <ErrorableRadioButtons label="test" value={makeField('test')} onValueChange={(_update) => {}}/>);
       sinon.assert.calledWithMatch(consoleStub, /Required prop `options` was not specified in `ErrorableRadioButtons`/);
     });
 
     it('options must be an object', () => {
       SkinDeep.shallowRender(
-        <ErrorableRadioButtons label="test" options onValueChange={(_update) => {}}/>);
+        <ErrorableRadioButtons label="test" options value={makeField('test')} onValueChange={(_update) => {}}/>);
       sinon.assert.calledWithMatch(consoleStub, /Invalid prop `options` of type `boolean` supplied to `ErrorableRadioButtons`, expected an array/);
     });
   });
@@ -59,7 +60,7 @@ describe('<ErrorableRadioButtons>', () => {
 
     const updatePromise = new Promise((resolve, _reject) => {
       myRadioButtons = SkinDeep.shallowRender(
-        <ErrorableRadioButtons label="test" options={options} onValueChange={(update) => { resolve(update); }}/>
+        <ErrorableRadioButtons label="test" options={options} value={makeField('test')} onValueChange={(update) => { resolve(update); }}/>
       );
       done();
     });
@@ -72,7 +73,7 @@ describe('<ErrorableRadioButtons>', () => {
 
   it('label attribute propagates', () => {
     const tree = SkinDeep.shallowRender(
-      <ErrorableRadioButtons label="my label" options={options} onValueChange={(_update) => {}}/>);
+      <ErrorableRadioButtons label="my label" options={options} value={makeField('test')} onValueChange={(_update) => {}}/>);
 
     // Ensure label text is correct.
     const labels = tree.everySubTree('label');


### PR DESCRIPTION
This PR is mainly an attempt to change our store to not be dependent on the structure of the form (remove fields from being nested within sections and instead fields are all at the same level). The following main changes were made to accomplish this:
1. Passing the entire veteran data store to each section component
2. Changing the UI store to capture the fields that are in each section (this is needed for the initialization function that dirties all the fields in a given section, since the veteran store no longer contains section logic)

I am not confident that 2 above is the right solution to the problem, but it was the best I could come up with. Would love to get feedback on this.

This PR is a major change to how our application processes data, so would love if @alexose could look at the store from an API perspective and if @awong-dev could look see if the approach makes sense.
