### PR TITLE
Add icons to secondary action buttons and change styling

### DIFF
--- a/assets/css/hca.scss
+++ b/assets/css/hca.scss
@@ -44,6 +44,11 @@ legend {
   max-width: 47rem;
 }
 
+button.short {
+  font-weight: 500;
+  padding: 1rem;
+}
+
 button.usa-button-outline {
   box-shadow: $button-stroke $color-primary;
 
@@ -63,6 +68,11 @@ button.usa-button-outline {
   &.usa-button-focus {
     box-shadow: $button-stroke $color-primary-darkest, $focus-shadow;
   }
+}
+
+button i.fa {
+  font-size: 0.75em;
+  margin-right: 0.5em;
 }
 
 .progress-box {

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -27,6 +27,9 @@
 @import "~uswds/src/stylesheets/components/forms";
 @import "~uswds/src/stylesheets/components/sidenav";
 
+// Font Awesome
+@import "~font-awesome/scss/font-awesome";
+
 // And finally, our own style sheet.
 @import "va-variables";
 @import "va";

--- a/src/client/components/form-elements/GrowableTable.jsx
+++ b/src/client/components/form-elements/GrowableTable.jsx
@@ -108,10 +108,10 @@ class GrowableTable extends React.Component {
                   })}
               </div>
               <div className="small-3 columns">
-                <button onClick={(event) => this.handleEdit(event)} data-key={obj.key}>Edit</button>
+                <button className="usa-button-outline short" onClick={(event) => this.handleEdit(event)} data-key={obj.key}><i className="fa fa-pencil"></i>Edit</button>
               </div>
               <div className="small-3 columns">
-                <button onClick={this.handleRemove} data-index={index}>Remove</button>
+                <button className="usa-button-outline short" onClick={this.handleRemove} data-index={index}><i className="fa fa-trash-o"></i>Remove</button>
               </div>
             </div>
             <hr/>
@@ -122,7 +122,7 @@ class GrowableTable extends React.Component {
           <div key={reactKey++}>
             <div className="row">
               <div className="small-3 right columns">
-                <button onClick={this.handleRemove} data-index={index}>Remove</button>
+                <button className="usa-button-outline short" onClick={this.handleRemove} data-index={index}><i className="fa fa-trash-o"></i>Remove</button>
               </div>
             </div>
             <div className="row" key={obj.key}>
@@ -142,7 +142,7 @@ class GrowableTable extends React.Component {
             </div>
             <div className="row">
               <div className="small-3 right columns">
-                <button onClick={(event) => this.handleSave(event)} data-key={obj.key}>Save</button>
+                <button className="short" onClick={(event) => this.handleSave(event)} data-key={obj.key}><i className="fa fa-check"></i>Save</button>
               </div>
             </div>
             <hr/>
@@ -159,7 +159,7 @@ class GrowableTable extends React.Component {
         {rowElements}
         <div className="row">
           <div className="small-3 small-centered columns">
-            <button onClick={this.handleAdd}>Add</button>
+            <button className="usa-button-outline short" onClick={this.handleAdd}><i className="fa fa-plus"></i>Add</button>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Change styles of secondary action buttons to be outline style except for "Save" button. Also added icons to differentiate and reinforce the actions. 

Question to group: Do we want to hide the "Add" button until "Save" is clicked?

<img width="536" alt="screen shot 2016-05-11 at 9 03 16 pm" src="https://cloud.githubusercontent.com/assets/3886085/15201178/2aa131d8-17bc-11e6-8794-819f6fe41f83.png">
