### PR TITLE
Match up loopback mount and api root paths.

### DIFF
--- a/hca-api-stub/voa-rest.js
+++ b/hca-api-stub/voa-rest.js
@@ -7,7 +7,7 @@ const veteranToSaveSubmitForm = require('../src/server/enrollment-system').veter
 var securityArtifacts; // eslint-disable-line
 
 function attach(app) {
-  app.set('restApiRoot', '/v1/api');
+  app.set('restApiRoot', '/api/hca/v1');
 
   // TODO: use `NODE_ENV` should probably determining which endpoint is selected.
   const endpoint = {
@@ -111,7 +111,7 @@ function attach(app) {
             http: { source: 'body' } }
         ],
         returns: { arg: 'result', type: 'string', root: true },
-        http: { verb: 'post', path: '/submit' }
+        http: { path: '/submit' }
       }
     );
 
@@ -134,7 +134,7 @@ function attach(app) {
 
     // API explorer (if present)
     try {
-      const explorer = require('loopback-component-explorer')(app, { basePath: '/hca', mountPath: '/explorer' });
+      const explorer = require('loopback-component-explorer')(app, { basePath: app.get('restApiRoot'), mountPath: '/explorer' });
       app.once('started', (baseUrl) => {
         console.log('Browse your REST API at %s%s', baseUrl, explorer.route);
       });

--- a/src/client/components/HealthCareApp.jsx
+++ b/src/client/components/HealthCareApp.jsx
@@ -99,7 +99,7 @@ class HealthCareApp extends React.Component {
     store.dispatch(updateCompletedStatus(path));
 
     // POST data to endpoint
-    fetch('/v1/api/submit', {
+    fetch('/v1/api/VoaServices/submit', {
       method: 'POST',
       header: {
         Accept: 'application/json',

--- a/src/client/reducers/veteran/index.js
+++ b/src/client/reducers/veteran/index.js
@@ -231,7 +231,7 @@ export const completeVeteran = {
     },
     city: {
       value: 'Washington',
-      dirty: falseph
+      dirty: false
     },
     country: {
       value: 'USA',

--- a/src/server.js
+++ b/src/server.js
@@ -50,6 +50,6 @@ function makeServer() {
 const server = makeServer();
 const api = loopback();
 voaRest.attach(api);
-server.use('/hca', api);
+server.use('/', api);
 
 server.listen(port);


### PR DESCRIPTION
The Loopback server expects to be mounted on '/'.  The 'restApiRoot' is
then used to filter requests down.

Previously, the server was mounted under /hca which confused it because
the generated paths were expecting /v1/api/{resource} but express was
configured to route to /hca/v1/api{resource}.
