### PR TITLE
Reduce veteran JSON a little further

### DIFF
--- a/src/client/components/HealthCareApp.jsx
+++ b/src/client/components/HealthCareApp.jsx
@@ -88,9 +88,9 @@ class HealthCareApp extends React.Component {
     const store = this.context.store;
     const veteran = store.getState().veteran;
 
-    // Strip out unnecessary fields'
-    function reducer(key, value) {
-      return key === 'dirty' ? undefined : value;
+    // Strip out unnecessary fields that track UI state
+    function reducer(i, d) {
+      return typeof d.value !== 'undefined' ? d.value : d;
     }
     const json = JSON.stringify(veteran, reducer, 4);
     console.log(json);


### PR DESCRIPTION
Per @awong-dev 's request, this turns any field that looks like this:

`"veteranSocialSecurityNumber": {
    "value": "",
    "dirty": false
  },`

into

`"veteranSocialSecurityNumber": "",`
