### PR TITLE
Set dev endpoint as the default.

### DIFF
--- a/hca-api-stub/voa-rest.js
+++ b/hca-api-stub/voa-rest.js
@@ -74,9 +74,7 @@ function attach(app) {
       connector: require('loopback-connector-soap'),
       remotingEnabled: true,
       wsdl: path.join(__dirname, './voa.wsdl'),
-      url: endpoint.esPreprod,
-//      wsdl: endpoint.esDev + '?wsdl',
-//      url: endpoint.esDev,
+      url: endpoint.esDev,
       security: securityArtifacts,
       wsdl_options: securityArtifacts === null ? null : { // eslint-disable-line
         rejectUnauthorized: false,


### PR DESCRIPTION
Most of our testing should be against dev anyways. Might as well make
this the default.
