### PR TITLE
Redirect to landing if previous sections are not complete

### DIFF
--- a/src/client/components/HealthCareApp.jsx
+++ b/src/client/components/HealthCareApp.jsx
@@ -28,6 +28,15 @@ class HealthCareApp extends React.Component {
     this.handleContinue = this.handleContinue.bind(this);
     this.handleSubmit = this.handleSubmit.bind(this);
     this.getUrl = this.getUrl.bind(this);
+    this.redirect = this.redirect.bind(this);
+  }
+
+  componentWillMount() {
+    this.redirect();
+  }
+
+  componentDidUpdate() {
+    window.addEventListener('hashchange', this.redirect());
   }
 
   getUrl(direction) {
@@ -63,6 +72,27 @@ class HealthCareApp extends React.Component {
       delay: 0,
       smooth: true,
     });
+  }
+
+  redirect() {
+    // TODO (anne): Refactor and add redirect message using query params
+    const previousPaths = [];
+    const currentPath = this.props.location.pathname;
+    const paths = _.keys(this.props.uiState.sections);
+
+    for (let i = 0; i < paths.length; i++) {
+      if (paths[i] === currentPath) {
+        break;
+      }
+      previousPaths.push(paths[i]);
+    }
+
+    for (let j = 0; j < previousPaths.length; j++) {
+      if (this.props.uiState.sections[previousPaths[j]].complete === false) {
+        this.context.router.push('/introduction');
+        break;
+      }
+    }
   }
 
   handleContinue() {


### PR DESCRIPTION
There are 2 scenarios where we want to redirect users to the introduction page (to prevent them from breaking the form logic that depends on moving linearly through the form): 
1. Force refresh
2. Going directly to a url

Not sure the way I'm handling this for the second scenario is ideal.
