### PR TITLE
Adding CLI tools for submit and status.

### DIFF
--- a/scripts/status.sh
+++ b/scripts/status.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Usage: ./status.sh FORMSUBMISSIONID
+# Creates a GET request from the provided FORMSUBMISSIONID.
+# Prints backend results upon completion.
+[ "$1" = "" ] && exit
+curl -X GET --header "Accept: application/json" \
+  "http://localhost:3000/api/hca/v1/VoaServices/status?request=%7B%22formSubmissionId%22%3A"$1"%7D"
+echo

--- a/scripts/submit.sh
+++ b/scripts/submit.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Usage: ./submit.sh FILE
+# Posts FILE (containing JSON data in the format used by the veteran form store)
+# to a local instance of the backend server.
+# Prints backend results upon completion.
+[ ! -r "$1" ] && exit 1
+curl -X POST --header "Content-Type: application/json" \
+  --header "Accept: application/json" \
+  -d "$(cat $1)" \
+  "http://localhost:3000/api/hca/v1/VoaServices/submit"
+echo


### PR DESCRIPTION
Two simple tools added here for local back-end testing:

```
# Usage: ./submit.sh FILE
# Posts FILE (containing JSON data in the format used by the veteran form store)
# to a local instance of the backend server.
# Prints backend results upon completion.
```

```
# Usage: ./status.sh FORMSUBMISSIONID
# Creates a GET request from the provided FORMSUBMISSIONID.
# Prints backend results upon completion.
```
