### PR TITLE
Add mock API

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,6 +438,12 @@ The backend API is a pass-through to a soap service which is not accessible duri
 To facilitate complete end-to-end tests, the API server can be placed into mock mode by setting
 the `HCA_MOCK_API=1` environment variable.
 
+```
+HCA_MOCK_API=1 npm run watch
+```
+
+is possibly a way to develop against it.
+
 End-to-end tests can then configure the mock by POSTing short configuration command to
 the `api/hca/v1/mock` endpoint.  Commands are are `application/json` POST bodies with the
 following structure:

--- a/README.md
+++ b/README.md
@@ -432,7 +432,23 @@ Once selenium server is running, in a seperate terminal you should be able to ru
 ```bash
 npm run tests:e2e
 ```
- 
+
+##### Mocking the API for e2e tests
+The backend API is a pass-through to a soap service which is not accessible during testing.
+To facilitate complete end-to-end tests, the API server can be placed into mock mode by setting
+the `HCA_MOCK_API=1` environment variable.
+
+End-to-end tests can then configure the mock by POSTing short configuration command to
+the `api/hca/v1/mock` endpoint.  Commands are are `application/json` POST bodies with the
+following structure:
+
+```
+{ resource: 'endpoint', value: '{more_json:1}', verb: 'get' }
+```
+
+POSTing this to command would make GET requests to `/api/hca/v1/endpoint` return `{more_json:1}`.
+Note that the verb can be left out and it will default to `get`. The verb is case insensitive.
+
 
 ### Docker
 #### Environment setup

--- a/src/server.js
+++ b/src/server.js
@@ -5,8 +5,9 @@ const winston = require('winston');
 
 const options = { logger: winston };
 const config = require('../config');
-const application = require('./server/routes/application')(options);
-const status = require('./server/routes/status')(options);
+const application = require('./server/routes/application');
+const status = require('./server/routes/status');
+const mockapi = require('./server/routes/mockapi');
 
 const port = config.port;
 
@@ -61,7 +62,11 @@ if (process.env.NODE_TLS_REJECT_UNAUTHORIZED === '0') {
 const app = makeApp();
 app.use(morgan('combined'));
 app.use(bodyParser.json());
-app.use(`${config.apiRoot}/application`, application);
-app.use(`${config.apiRoot}/status`, status);
+if (process.env.HCA_MOCK_API !== '1') {
+  app.use(`${config.apiRoot}/application`, application(options));
+  app.use(`${config.apiRoot}/status`, status(options));
+} else {
+  app.use(`${config.apiRoot}`, mockapi(options));
+}
 
 app.listen(port);

--- a/src/server/routes/mockapi.js
+++ b/src/server/routes/mockapi.js
@@ -1,0 +1,36 @@
+'use strict'; // eslint-disable-line
+
+const router = require('express').Router(); // eslint-disable-line
+
+function returnRouter(options) {
+  const mockResponses = {};
+
+  router.post('/mock', (req, res) => {
+    const verb = (req.body.verb || 'get').toLowerCase();
+    mockResponses[verb] = mockResponses[verb] || {};
+    mockResponses[verb][req.body.resource] = req.body.value;
+    const result = { result: `set ${verb} ${req.body.resource} to ${req.body.value}` };
+    options.logger.info(result);
+    res.status(200).json(result);
+  });
+
+  router.all('/:resource', (req, res) => {
+    const verb = req.method.toLowerCase();
+    const verbResponses = mockResponses[verb];
+    let result = null;
+    if (verbResponses) {
+      result = verbResponses[req.params.resource];
+    }
+
+    if (!result) {
+      res.status(500);
+      result = { error: `mock not initialized for ${verb} ${req.params.resource}` };
+    }
+    options.logger.info(result);
+    res.json(result);
+  });
+
+  return router;
+}
+
+module.exports = returnRouter;

--- a/test/server/routes/mockapi.spec.js
+++ b/test/server/routes/mockapi.spec.js
@@ -1,0 +1,96 @@
+'use strict'; // eslint-disable-line
+
+const bodyParser = require('body-parser');
+const express = require('express');
+const request = require('supertest');
+
+const mockapi = require('../../../src/server/routes/mockapi');
+
+// Mock out the logger.
+const options = { logger: { info: () => {} } };
+
+describe('mock api', () => {
+  describe('/resource1 with no mock set', () => {
+    const app = express();
+    app.use(bodyParser.json());
+    app.use('/', mockapi(options));
+
+    it('should return a 500 error', (done) => {
+      request(app)
+        .get('/resource1')
+        .expect(500)
+        .end(done);
+    });
+  });
+
+  describe('/resource1 with mocked get', () => {
+    let app = null;
+    beforeEach((done) => {
+      app = express();
+      app.use(bodyParser.json());
+      app.use('/', mockapi(options));
+
+      request(app)
+        .post('/mock')
+        .send({ resource: 'resource1', value: { poopy: 1 } })
+        .expect(200, done);
+    });
+    it('should return set value', (done) => {
+      request(app)
+        .get('/resource1')
+        .expect(200)
+        .expect({ poopy: 1 }, done);
+    });
+    it('should not affect unrelated verbs', (done) => {
+      request(app)
+        .post('/resource1')
+        .expect(500, done);
+    });
+    it('should not affect unrelated resources', (done) => {
+      request(app)
+        .get('/resource2')
+        .expect(500, done);
+    });
+  });
+
+  describe('/resource1 with mocked post', () => {
+    let app = null;
+    beforeEach((done) => {
+      app = express();
+      app.use(bodyParser.json());
+      app.use('/', mockapi(options));
+
+      request(app)
+        .post('/mock')
+        .send({ resource: 'resource1', value: { stoopid: 1 }, verb: 'post' })
+        .expect(200, done);
+    });
+    it('should return set value', (done) => {
+      request(app)
+        .post('/resource1')
+        .expect(200)
+        .expect({ stoopid: 1 }, done);
+    });
+  });
+
+  describe('/resource1 using mixed case for the verb', () => {
+    let app = null;
+    beforeEach((done) => {
+      app = express();
+      app.use(bodyParser.json());
+      app.use('/', mockapi(options));
+
+      request(app)
+        .post('/mock')
+        .send({ resource: 'rEsOuRcE1', value: { grammmer: 42 }, verb: 'pUT' })
+        .expect(200, done);
+    });
+    it('should return set value', (done) => {
+      request(app)
+        .put('/rEsOuRcE1')
+        .expect(200)
+        .expect({ grammmer: 42 }, done);
+    });
+  });
+});
+

--- a/test/server/routes/status.spec.js
+++ b/test/server/routes/status.spec.js
@@ -1,12 +1,11 @@
+const express = require('express');
 const request = require('supertest');
 
-const status = require('../../../src/server/routes/status')();
-
-const express = require('express');
+const status = require('../../../src/server/routes/status');
 
 const app = express();
+app.use('/status', status());
 
-app.use('/status', status);
 describe('v1', () => {
   describe('/status', () => {
     it('should return a 501 error', (done) => {


### PR DESCRIPTION
Facilitates end-to-end testing by allowing the server to be run in a mode where the test case can script API responses.
