### PR TITLE
Use synchronization instead of pauses for navs.

### DIFF
--- a/src/client/components/HealthCareApp.jsx
+++ b/src/client/components/HealthCareApp.jsx
@@ -262,6 +262,7 @@ class HealthCareApp extends React.Component {
             </div>
           </div>
         </div>
+        <span className="js-test-location hidden" data-location={this.props.location.pathname} hidden></span>
       </div>
     );
   }

--- a/test/e2e/tests/00-begin.js
+++ b/test/e2e/tests/00-begin.js
@@ -6,14 +6,16 @@ const url = 'http://localhost:' + config.port; // eslint-disable-line
 
 // Test timeout constants
 // TODO(awong): Move to a common file usable for all tests.
-const defaultTimeout = 500;   // The normal timeout to use. For most opreations w/o a server roundtrip, this should be more than fast enough.
-const slowTimeout = 1000;     // A slow timeout incase the page is doing something complex.
-const molassesTimeout = 5000; // A really really slow timeout. This should rarely be used.
+const timeouts = {
+  normal: 500,     // The normal timeout to use. For most opreations w/o a server roundtrip, this should be more than fast enough.
+  slow: 1000,      // A slow timeout incase the page is doing something complex.
+  molasses: 5000,  // A really really slow timeout. This should rarely be used.
+};
 
 // TODO(awong): Move this into a custom command or assertion that can be used with client.expect.element().
-function expectNavigateAwayFrom(client, url) {
-    client.expect.element('.js-test-location').attribute('data-location')
-      .to.not.contain(url).before(defaultTimeout);
+function expectNavigateAwayFrom(client, urlSubstring) {
+  client.expect.element('.js-test-location').attribute('data-location')
+    .to.not.contain(urlSubstring).before(timeouts.normal);
 }
 
 module.exports = {
@@ -23,9 +25,9 @@ module.exports = {
     // Ensure introduction page renders.
     client
       .url(url)
-      .waitForElementVisible('body', defaultTimeout)
+      .waitForElementVisible('body', timeouts.normal)
       .assert.title('Apply for Health Care: Vets.gov')
-      .waitForElementVisible('.form-panel', slowTimeout)  // First render of React may be slow.
+      .waitForElementVisible('.form-panel', timeouts.slow)  // First render of React may be slow.
       .click('.form-panel .usa-button-primary');
     expectNavigateAwayFrom(client, '/introduction');
 
@@ -111,8 +113,8 @@ module.exports = {
     client.expect.element('select[name="maritalStatus"]').to.be.visible;
     client
       .setValue('select[name="maritalStatus"]', 'Married')
-      .click('.form-panel')
-    client.expect.element('input[name="fname"]').to.be.visible.before(defaultTimeout);
+      .click('.form-panel');
+    client.expect.element('input[name="fname"]').to.be.visible.before(timeouts.normal);
 
     client
       .setValue('input[name="fname"]', 'Anne')
@@ -125,7 +127,7 @@ module.exports = {
       .setValue('select[name="marriageDay"]', '1')
       .setValue('input[name="marriageYear"]', '2010')
       .click('input[name="sameAddress-1"] + label');
-    client.expect.element('input[name="address"]').to.be.visible.before(defaultTimeout);
+    client.expect.element('input[name="address"]').to.be.visible.before(timeouts.normal);
 
     client
       .setValue('input[name="address"]', '115 S Michigan Ave')
@@ -140,7 +142,7 @@ module.exports = {
     // Child Information Page.
     client.expect.element('input[name="hasChildrenToReport-0"] + label').to.be.visible;
     client.click('input[name="hasChildrenToReport-0"] + label');
-    client.expect.element('input[name="fname"]').to.be.visible.before(defaultTimeout);
+    client.expect.element('input[name="fname"]').to.be.visible.before(timeouts.normal);
     client
       .setValue('input[name="fname"]', 'Hamnet')
       .setValue('input[name="lname"]', 'Shakespeare')
@@ -176,7 +178,7 @@ module.exports = {
     // Insurance Information Page.
     client.expect.element('input[name="isCoveredByHealthInsurance-0"] + label').to.be.visible;
     client.click('input[name="isCoveredByHealthInsurance-0"] + label');
-    client.expect.element('input[name="insuranceName"]').to.be.visible.before(defaultTimeout);
+    client.expect.element('input[name="insuranceName"]').to.be.visible.before(timeouts.normal);
     client
       .setValue('input[name="insuranceName"]', 'BCBS')
       .setValue('input[name="insurancePolicyHolderName"]', 'William Shakespeare')

--- a/test/e2e/tests/00-begin.js
+++ b/test/e2e/tests/00-begin.js
@@ -4,44 +4,76 @@ const config = require('../../../config');
 // FIXME: This should come in from a config variable
 const url = 'http://localhost:' + config.port; // eslint-disable-line
 
+// Test timeout constants
+// TODO(awong): Move to a common file usable for all tests.
+const defaultTimeout = 500;   // The normal timeout to use. For most opreations w/o a server roundtrip, this should be more than fast enough.
+const slowTimeout = 1000;     // A slow timeout incase the page is doing something complex.
+const molassesTimeout = 5000; // A really really slow timeout. This should rarely be used.
+
+// TODO(awong): Move this into a custom command or assertion that can be used with client.expect.element().
+function expectNavigateAwayFrom(client, url) {
+    client.expect.element('.js-test-location').attribute('data-location')
+      .to.not.contain(url).before(defaultTimeout);
+}
+
 module.exports = {
   'Begin application': (client) => {
     console.log(url);
+
+    // Ensure introduction page renders.
     client
       .url(url)
-      .waitForElementVisible('body', 1000)
+      .waitForElementVisible('body', defaultTimeout)
       .assert.title('Apply for Health Care: Vets.gov')
-      .waitForElementVisible('.form-panel', 3000)
-      .click('.form-panel .usa-button-primary')
-      .pause(1000)
-      .assert.visible('input[name="fname"]')
+      .waitForElementVisible('.form-panel', slowTimeout)  // First render of React may be slow.
+      .click('.form-panel .usa-button-primary');
+    expectNavigateAwayFrom(client, '/introduction');
+
+    // Personal Information page.
+    client.expect.element('input[name="fname"]').to.be.visible;
+    client
       .setValue('input[name="fname"]', 'William')
       .setValue('input[name="lname"]', 'Shakespeare')
-      .click('.form-panel .usa-button-primary')
-      .pause(1000)
-      .assert.visible('select[name="veteranBirthMonth"]')
+      .click('.form-panel .usa-button-primary');
+    expectNavigateAwayFrom(client, '/veteran-information/personal-information');
+
+    // Birth information page.
+    client.expect.element('select[name="veteranBirthMonth"]').to.be.visible;
+    client
       .setValue('select[name="veteranBirthMonth"]', 'Apr')
       .setValue('select[name="veteranBirthDay"]', '23')
       .setValue('input[name="veteranBirthYear"]', '1980')
       .setValue('input[name="ssn"]', '111-22-3333')
-      .click('.form-panel .usa-button-primary')
-      .pause(1000)
-      .assert.visible('select[name="gender"]')
+      .click('.form-panel .usa-button-primary');
+    expectNavigateAwayFrom(client, '/veteran-information/birth-information');
+
+    // Demographic information page.
+    client.expect.element('select[name="gender"]').to.be.visible;
+    client
       .setValue('select[name="gender"]', 'M')
-      .click('.form-panel .usa-button-primary')
-      .pause(1000)
-      .assert.visible('input[name="address"]')
+      .click('.form-panel .usa-button-primary');
+    expectNavigateAwayFrom(client, '/veteran-information/demographic-information');
+
+    // Veteran Address page.
+    client.expect.element('input[name="address"]').to.be.visible;
+    client
       .setValue('input[name="address"]', '111 S Michigan Ave')
       .setValue('input[name="city"]', 'Chicago')
       .setValue('select[name="country"]', 'USA')
       .setValue('select[name="state"]', 'IL')
       .setValue('input[name="zip"]', '60603')
-      .click('.form-panel .usa-button-primary')
-      .pause(1000)
-      .assert.visible('input[name="email"]')
-      .click('.form-panel .usa-button-primary')
-      .pause(1000)
-      .assert.visible('select[name="lastServiceBranch"]')
+      .click('.form-panel .usa-button-primary');
+    expectNavigateAwayFrom(client, '/veteran-information/veteran-address');
+
+    // Contact Information Page.
+    client.expect.element('input[name="email"]').to.be.visible;
+    client
+      .click('.form-panel .usa-button-primary');
+    expectNavigateAwayFrom(client, '/veteran-information/contact-information');
+
+    // Military Service Information Page.
+    client.expect.element('select[name="lastServiceBranch"]').to.be.visible;
+    client
       .setValue('select[name="lastServiceBranch"]', 'army')
       .setValue('select[name="lastEntryMonth"]', 'Oct')
       .setValue('select[name="lastEntryDay"]', '10')
@@ -50,26 +82,39 @@ module.exports = {
       .setValue('select[name="lastDischargeDay"]', '11')
       .setValue('input[name="lastDischargeYear"]', '2004')
       .setValue('select[name="dischargeType"]', 'honorable')
-      .click('.form-panel .usa-button-primary')
-      .pause(1000)
-      .assert.visible('input[name="purpleHeartRecipient"] + label')
-      .click('.form-panel .usa-button-primary')
-      .pause(1000)
-      .assert.visible('input[name="compensableVaServiceConnected-0"] + label')
+      .click('.form-panel .usa-button-primary');
+    expectNavigateAwayFrom(client, '/military-service/service-information');
+
+    // Military Service Additional Information Page.
+    client.expect.element('input[name="purpleHeartRecipient"] + label').to.be.visible;
+    client
+      .click('.form-panel .usa-button-primary');
+    expectNavigateAwayFrom(client, '/military-service/additional-information');
+
+    // VA Benefits Basic Info page.
+    client.expect.element('input[name="compensableVaServiceConnected-0"] + label').to.be.visible;
+    client
       .click('input[name="compensableVaServiceConnected-0"] + label')
       .click('input[name="isVaServiceConnected-0"] + label')
       .click('input[name="receivesVaPension-0"] + label')
-      .click('.form-panel .usa-button-primary')
-      .pause(1000)
-      .assert.visible('input[name="provideFinancialInfo-0"] + label')
+      .click('.form-panel .usa-button-primary');
+    expectNavigateAwayFrom(client, '/va-benefits/basic-information');
+
+    // Financial disclosure page.
+    client.expect.element('input[name="provideFinancialInfo-0"] + label').to.be.visible;
+    client
       .click('input[name="provideFinancialInfo-0"] + label')
-      .click('.form-panel .usa-button-primary')
-      .pause(1000)
-      .assert.visible('select[name="maritalStatus"]')
+      .click('.form-panel .usa-button-primary');
+    expectNavigateAwayFrom(client, '/household-information/financial-disclosure');
+
+    // Spouse information Page.
+    client.expect.element('select[name="maritalStatus"]').to.be.visible;
+    client
       .setValue('select[name="maritalStatus"]', 'Married')
       .click('.form-panel')
-      .waitForElementVisible('input[name="fname"]', 1000)
-      .assert.visible('input[name="fname"]')
+    client.expect.element('input[name="fname"]').to.be.visible.before(defaultTimeout);
+
+    client
       .setValue('input[name="fname"]', 'Anne')
       .setValue('input[name="lname"]', 'Hathaway')
       .setValue('input[name="ssn"]', '444-55-6666')
@@ -79,20 +124,24 @@ module.exports = {
       .setValue('select[name="marriageMonth"]', 'Jun')
       .setValue('select[name="marriageDay"]', '1')
       .setValue('input[name="marriageYear"]', '2010')
-      .click('input[name="sameAddress-1"] + label')
-      .waitForElementVisible('input[name="address"]', 1000)
-      .assert.visible('input[name="address"]')
+      .click('input[name="sameAddress-1"] + label');
+    client.expect.element('input[name="address"]').to.be.visible.before(defaultTimeout);
+
+    client
       .setValue('input[name="address"]', '115 S Michigan Ave')
       .setValue('input[name="city"]', 'Chicago')
       .setValue('select[name="country"]', 'USA')
       .setValue('select[name="state"]', 'IL')
       .setValue('input[name="zip"]', '60603')
-      .click('.form-panel .usa-button-primary')
-      .pause(1000)
-      .assert.visible('input[name="hasChildrenToReport-0"] + label')
-      .click('input[name="hasChildrenToReport-0"] + label')
-      .waitForElementVisible('input[name="fname"]', 1000)
-      .assert.visible('input[name="fname"]')
+      .click('.form-panel .usa-button-primary');
+    expectNavigateAwayFrom(client, '/household-information/spouse-information');
+
+
+    // Child Information Page.
+    client.expect.element('input[name="hasChildrenToReport-0"] + label').to.be.visible;
+    client.click('input[name="hasChildrenToReport-0"] + label');
+    client.expect.element('input[name="fname"]').to.be.visible.before(defaultTimeout);
+    client
       .setValue('input[name="fname"]', 'Hamnet')
       .setValue('input[name="lname"]', 'Shakespeare')
       .setValue('select[name="childRelation"]', 'Son')
@@ -103,38 +152,55 @@ module.exports = {
       .setValue('select[name="childBecameDependentMonth"]', 'Feb')
       .setValue('select[name="childBecameDependentDay"]', '2')
       .setValue('input[name="childBecameDependentYear"]', '2012')
-      .click('.form-panel .usa-button-primary')
-      .pause(1000)
-      .assert.visible('input[name="veteranGrossIncome"]')
-      .click('.form-panel .usa-button-primary')
-      .pause(1000)
-      .assert.visible('input[name="deductibleMedicalExpenses"]')
-      .click('.form-panel .usa-button-primary')
-      .pause(1000)
-      .assert.visible('input[name="isMedicaidEligible-0"] + label')
+      .click('.form-panel .usa-button-primary');
+    expectNavigateAwayFrom(client, '/household-information/child-information');
+
+    // Annual Income Page.
+    client.expect.element('input[name="veteranGrossIncome"]').to.be.visible;
+    client.click('.form-panel .usa-button-primary');
+    expectNavigateAwayFrom(client, '/household-information/annual-income');
+
+    // Deductible Expenses Page.
+    client.expect.element('input[name="deductibleMedicalExpenses"]').to.be.visible;
+    client.click('.form-panel .usa-button-primary');
+    expectNavigateAwayFrom(client, '/household-information/deductible-expenses');
+
+    // Medicare and Medicaid Page.
+    client.expect.element('input[name="isMedicaidEligible-0"] + label').to.be.visible;
+    client
       .click('input[name="isMedicaidEligible-1"] + label')
       .click('input[name="isEnrolledMedicarePartA-1"] + label')
-      .click('.form-panel .usa-button-primary')
-      .pause(1000)
-      .assert.visible('input[name="isCoveredByHealthInsurance-0"] + label')
-      .click('input[name="isCoveredByHealthInsurance-0"] + label')
-      .waitForElementVisible('input[name="insuranceName"]', 1000)
-      .assert.visible('input[name="insuranceName"]')
+      .click('.form-panel .usa-button-primary');
+    expectNavigateAwayFrom(client, '/insurance-information/medicare');
+
+    // Insurance Information Page.
+    client.expect.element('input[name="isCoveredByHealthInsurance-0"] + label').to.be.visible;
+    client.click('input[name="isCoveredByHealthInsurance-0"] + label');
+    client.expect.element('input[name="insuranceName"]').to.be.visible.before(defaultTimeout);
+    client
       .setValue('input[name="insuranceName"]', 'BCBS')
       .setValue('input[name="insurancePolicyHolderName"]', 'William Shakespeare')
       .setValue('input[name="insurancePolicyNumber"]', '100')
-      .click('.form-panel .usa-button-primary')
-      .pause(1000)
-      .assert.visible('select[name="state"]')
+      .click('.form-panel .usa-button-primary');
+    expectNavigateAwayFrom(client, '/insurance-information/general');
+
+    // Additional VA Insurance Information Page.
+    client.expect.element('select[name="state"]').to.be.visible;
+    client
       .setValue('select[name="state"]', 'IL')
       .setValue('select[name="vaMedicalFacility"]', 'EVANSTON CBOC')
-      .click('.form-panel .usa-button-primary')
-      .pause(1000)
-      .assert.visible('button.edit-btn')
-      .click('.form-panel .usa-button-primary')
-      .pause(1000)
-      // TODO: test that submission works and they are redirect to the confirmation page
-      .closeWindow();
+      .click('.form-panel .usa-button-primary');
+    expectNavigateAwayFrom(client, '/insurance-information/va-facility');
+
+    // Review and Submit Page.
+    client.expect.element('button.edit-btn').to.be.visible;
+    client.click('.form-panel .usa-button-primary');
+    // TODO: test that submission works and they are redirect to the confirmation page. Uncomment
+    // this expectation when that works.
+    // expectNavigateAwayFrom(client, '/review-and-submit');
+
+
+    client.end();
   },
   tearDown: report
 };


### PR DESCRIPTION
Using pause() in unittests to synchronize events (eg, waiting for a
navigation to occur after a click) is a major anti-pattern for any sort of
automated testing. Nightwatch example code in their documentation for some
reason shows this pattern but it is terrible and should not be used
because in the best case, it makes your test a lot slower than it needs
to be (most conditions seem to be meetable in tens of ms not 1000ms) and
in the worst case leads to flaky behavior because there is no stated
event to wait for.

This PR removes all calls to pause() and introduces test timeout
constants that can be adjusted globally (or maybe per environment) to
handle slower network connections in Travis, etc. Synchronization is
done by adding a little bit of instrumetnation into the top level
reaction component that allows for easy querying of the current
URL that React thinks it is rendering.

The PR also uses chai expect syntax for text expectations and only uses
nightwatch commands when directly accessing the browser/client object.
There's no great reason for this but the documentation makes it look
like the chai expect syntax is the future direction for nightwatch
so might as well use it now.
