### PR TITLE
Convert email addresses to lower case before comparing

### DIFF
--- a/src/client/components/veteran-information/ContactInformationSection.jsx
+++ b/src/client/components/veteran-information/ContactInformationSection.jsx
@@ -17,7 +17,7 @@ class ContactInformationSection extends React.Component {
   }
 
   confirmEmail() {
-    if (this.props.data.email.value !== this.props.data.emailConfirmation.value) {
+    if (this.props.data.email.value.toLowerCase() !== this.props.data.emailConfirmation.value.toLowerCase()) {
       return 'Please ensure your entries match';
     }
 


### PR DESCRIPTION
Currently the comparison between `email` and `emailConfirmation` is case sensitive, which it should not be. Convert both email addresses to lower case before comparing so they will not be case sensitive. 
