### PR TITLE
Remove spouseData from submission if there is no spouse

### DIFF
--- a/src/common/veteran.js
+++ b/src/common/veteran.js
@@ -641,6 +641,10 @@ const completeVeteran = {
 };
 
 function veteranToApplication(veteran) {
+  if (_.includes(['Never Married', 'Widowed', 'Divorced'], veteran.maritalStatus.value)) {
+    delete veteran.spouseAddress; // eslint-disable-line no-param-reassign
+  }
+
   return JSON.stringify(veteran, (key, value) => {
     // Remove properties that are not interesting to the API.
     switch (key) {


### PR DESCRIPTION
I'm sure there's a cleaner way to do this in the React component itself, but putting the logic in with the rest of the scrubbing in `veteranToApplication` seemed like a safe way to start.
