### PR TITLE
Change email serialization in SOAP

### DIFF
--- a/src/server/enrollment-system.js
+++ b/src/server/enrollment-system.js
@@ -120,6 +120,28 @@ function phoneNumberFromVeteran(veteran) {
 }
 
 /**
+ * Validates the email field for the veteran and returns the validated form or undefined
+ * since no email is required for the ES System.
+ *
+ * @param {Object} veteran The veteran resource
+ * @returns undefined|{Array} Undefined or an object containing the email wrapped in an array
+ */
+function emailFromVeteran(veteran) {
+  if (!veteran.email) {
+    return undefined;
+  }
+
+  return [
+    {
+      email: {
+        address: veteran.email,
+        type: '1'
+      }
+    }
+  ];
+}
+
+/**
  * Returns array of SDS codes representing the claimed races of the veteran.
  *
  * Codes are from the VHA Standard Data Service (ADRDEV01) HL7 24 Race Map List.
@@ -1094,14 +1116,7 @@ function veteranToDemographicsInfo(veteran) {
           addressTypeCode: 'P',  // TODO(awong): this code is from VHA Standard Data Service (ADRDEV01) Address Type List P==Permanent. Determine if we need it.
         },
       },
-      emails: {
-        email: [
-          {
-            address: veteran.email,
-            type: '1'
-          }
-        ]
-      },
+      emails: emailFromVeteran(veteran),
       phones: phoneNumberFromVeteran(veteran),
     },
     ethnicity: spanishHispanicToSDSCode(veteran.isSpanishHispanicLatino),

--- a/test/data/golden-soap-submission.json
+++ b/test/data/golden-soap-submission.json
@@ -19,14 +19,14 @@
               "addressTypeCode": "P"
             }
           },
-          "emails": {
-            "email": [
-              {
+          "emails": [
+            {
+              "email": {
                 "address": "foo@example.com",
                 "type": "1"
-              }
-            ]
-          },
+              }  
+            }
+          ],
           "phones": {
             "phone": [
               {


### PR DESCRIPTION
- Leave the emails/email nodes out entirely if no emails are provided
- Move the `email` into an array of `emails`, though we only have one for now

Closes #382
