### PR TITLE
Move GA tracking code for successful submissions inside response

### DIFF
--- a/src/client/components/HealthCareApp.jsx
+++ b/src/client/components/HealthCareApp.jsx
@@ -112,16 +112,17 @@ class HealthCareApp extends React.Component {
           this.props.onCompletedStatus(path);
           this.props.onUpdateSubmissionId(data.response.formSubmissionId);
           this.props.onUpdateSubmissionTimestamp(data.response.timeStamp);
+
+          window.dataLayer.push({
+            event: 'submission-successful',
+            submissionID: data.response.formSubmissionId
+          });
         });
+
         setTimeout(() => { // eslint-disable-line scanjs-rules/call_setTimeout
           this.context.router.push(this.getUrl('next'));
           this.scrollToTop();
         }, 1000);
-
-        window.dataLayer.push({
-          event: 'submission-successful',
-          submissionID: this.props.uiState.submission.id
-        });
       }).catch(error => {
         // TODO(crew): Pass meaningful errors to the client.
         setTimeout(() => { // eslint-disable-line scanjs-rules/call_setTimeout


### PR DESCRIPTION
GA was not tracking the submission id value. I think this is because the `dataLayer.push` was running before the response was received, therefore it didn't have the value of the id yet. Moving the `dataLayer.push` inside the response and sending the id directly from the response data to GA instead of using `this.props.uiState.submission.id`.
