### PR TITLE
rate limit healthcheck/es calls

### DIFF
--- a/config.js
+++ b/config.js
@@ -77,10 +77,12 @@ const config = {
   },
 
   environment: process.env.NODE_ENV || 'development',
-  // This is a valid form submission ID from the ES system that will be used by the health check to 
+  // This is a valid form submission ID from the ES system that will be used by the health check to
   // verify that the ES system is up.
   validFormSubmissionId: '377609264',
 
+  // Rate limit for doing ES status checks
+  esStatusRate : 1000 * 60
 };
 
 module.exports = config;


### PR DESCRIPTION
This prevents us from accidentally DDOSing `healthcheck/es` if we start hitting the endpoint a lot.

Related to https://github.com/department-of-veterans-affairs/devops/issues/307
