### PR TITLE
Re-insert Spouse and dependent data into the financial block

### DIFF
--- a/src/server/enrollment-system.js
+++ b/src/server/enrollment-system.js
@@ -341,9 +341,6 @@ function childToDependentInfo(child) {
  */
 function childToDependentFinancialsInfo(child) {
   const incomes = resourceToIncomeCollection(child);
-  if (!incomes) {
-    return undefined;
-  }
 
   return {
     incomes,
@@ -387,10 +384,6 @@ function veteranToSpouseFinancials(veteran) {
     netIncome: veteran.spouseNetIncome,
     otherIncome: veteran.spouseOtherIncome
   });
-
-  if (!spouseIncome) {
-    return undefined;
-  }
 
   // set cohabitedLastYear to false if not present or empty string
   let cohabitedLastYear = veteran.cohabitedLastYear;

--- a/test/data/conformance/child-financial.xml
+++ b/test/data/conformance/child-financial.xml
@@ -101,6 +101,34 @@
           <eeSummary:discloseFinancialInformation>true</eeSummary:discloseFinancialInformation>
         </eeSummary:incomeTest>
         <eeSummary:financialStatement>
+          <eeSummary:spouseFinancialsList>
+            <eeSummary:spouseFinancials>
+              <eeSummary:spouse>
+                <eeSummary:dob>04/06/1980</eeSummary:dob>
+                <eeSummary:givenName>FIRSTSPOUSE</eeSummary:givenName>
+                <eeSummary:middleName>MIDDLESPOUSE</eeSummary:middleName>
+                <eeSummary:familyName>LASTSPOUSE</eeSummary:familyName>
+                <eeSummary:suffix>SR.</eeSummary:suffix>
+                <eeSummary:relationship>2</eeSummary:relationship>
+                <eeSummary:startDate>05/10/1983</eeSummary:startDate>
+                <eeSummary:ssns>
+                  <eeSummary:ssn>
+                    <eeSummary:ssnText>111221234</eeSummary:ssnText>
+                  </eeSummary:ssn>
+                </eeSummary:ssns>
+                <eeSummary:address>
+                  <eeSummary:city>Dulles</eeSummary:city>
+                  <eeSummary:country>USA</eeSummary:country>
+                  <eeSummary:line1>123 NW 8th St</eeSummary:line1>
+                  <eeSummary:state>VA</eeSummary:state>
+                  <eeSummary:zipCode>20101</eeSummary:zipCode>
+                  <eeSummary:phoneNumber>1112221234</eeSummary:phoneNumber>
+                </eeSummary:address>
+              </eeSummary:spouse>
+              <eeSummary:contributedToSpousalSupport>false</eeSummary:contributedToSpousalSupport>
+              <eeSummary:livedWithPatient>true</eeSummary:livedWithPatient>
+            </eeSummary:spouseFinancials>
+          </eeSummary:spouseFinancialsList>
           <eeSummary:marriedLastCalendarYear>true</eeSummary:marriedLastCalendarYear>
           <eeSummary:dependentFinancialsList>
             <eeSummary:dependentFinancials>
@@ -136,6 +164,26 @@
               <eeSummary:incapableOfSelfSupport>true</eeSummary:incapableOfSelfSupport>
               <eeSummary:attendedSchool>true</eeSummary:attendedSchool>
               <eeSummary:contributedToSupport>false</eeSummary:contributedToSupport>
+            </eeSummary:dependentFinancials>
+            <eeSummary:dependentFinancials>
+              <eeSummary:dependentInfo>
+                <eeSummary:dob>03/07/1996</eeSummary:dob>
+                <eeSummary:givenName>FIRSTCHILDB</eeSummary:givenName>
+                <eeSummary:middleName>MIDDLECHILDB</eeSummary:middleName>
+                <eeSummary:familyName>LASTCHILDB</eeSummary:familyName>
+                <eeSummary:suffix>SR.</eeSummary:suffix>
+                <eeSummary:relationship>6</eeSummary:relationship>
+                <eeSummary:ssns>
+                  <eeSummary:ssn>
+                    <eeSummary:ssnText>222111234</eeSummary:ssnText>
+                  </eeSummary:ssn>
+                </eeSummary:ssns>
+                <eeSummary:startDate>04/07/2003</eeSummary:startDate>
+              </eeSummary:dependentInfo>
+              <eeSummary:livedWithPatient>false</eeSummary:livedWithPatient>
+              <eeSummary:incapableOfSelfSupport>false</eeSummary:incapableOfSelfSupport>
+              <eeSummary:attendedSchool>true</eeSummary:attendedSchool>
+              <eeSummary:contributedToSupport>true</eeSummary:contributedToSupport>
             </eeSummary:dependentFinancials>
           </eeSummary:dependentFinancialsList>
           <eeSummary:numberOfDependentChildren>2</eeSummary:numberOfDependentChildren>

--- a/test/data/conformance/no-financials-children.xml
+++ b/test/data/conformance/no-financials-children.xml
@@ -174,6 +174,48 @@
             </eeSummary:spouseFinancials>
           </eeSummary:spouseFinancialsList>
           <eeSummary:marriedLastCalendarYear>true</eeSummary:marriedLastCalendarYear>
+          <eeSummary:dependentFinancialsList>
+            <eeSummary:dependentFinancials>
+              <eeSummary:dependentInfo>
+                <eeSummary:dob>05/05/1982</eeSummary:dob>
+                <eeSummary:givenName>FIRSTCHILDA</eeSummary:givenName>
+                <eeSummary:middleName>MIDDLECHILDA</eeSummary:middleName>
+                <eeSummary:familyName>LASTCHILDA</eeSummary:familyName>
+                <eeSummary:suffix>JR.</eeSummary:suffix>
+                <eeSummary:relationship>5</eeSummary:relationship>
+                <eeSummary:ssns>
+                  <eeSummary:ssn>
+                    <eeSummary:ssnText>111229876</eeSummary:ssnText>
+                  </eeSummary:ssn>
+                </eeSummary:ssns>
+                <eeSummary:startDate>04/07/1992</eeSummary:startDate>
+              </eeSummary:dependentInfo>
+              <eeSummary:livedWithPatient>true</eeSummary:livedWithPatient>
+              <eeSummary:incapableOfSelfSupport>true</eeSummary:incapableOfSelfSupport>
+              <eeSummary:attendedSchool>true</eeSummary:attendedSchool>
+              <eeSummary:contributedToSupport>false</eeSummary:contributedToSupport>
+            </eeSummary:dependentFinancials>
+            <eeSummary:dependentFinancials>
+              <eeSummary:dependentInfo>
+                <eeSummary:dob>03/07/1996</eeSummary:dob>
+                <eeSummary:givenName>FIRSTCHILDB</eeSummary:givenName>
+                <eeSummary:middleName>MIDDLECHILDB</eeSummary:middleName>
+                <eeSummary:familyName>LASTCHILDB</eeSummary:familyName>
+                <eeSummary:suffix>SR.</eeSummary:suffix>
+                <eeSummary:relationship>6</eeSummary:relationship>
+                <eeSummary:ssns>
+                  <eeSummary:ssn>
+                    <eeSummary:ssnText>222111234</eeSummary:ssnText>
+                  </eeSummary:ssn>
+                </eeSummary:ssns>
+                <eeSummary:startDate>04/07/2003</eeSummary:startDate>
+              </eeSummary:dependentInfo>
+              <eeSummary:livedWithPatient>false</eeSummary:livedWithPatient>
+              <eeSummary:incapableOfSelfSupport>false</eeSummary:incapableOfSelfSupport>
+              <eeSummary:attendedSchool>true</eeSummary:attendedSchool>
+              <eeSummary:contributedToSupport>true</eeSummary:contributedToSupport>
+            </eeSummary:dependentFinancials>
+          </eeSummary:dependentFinancialsList>
           <eeSummary:numberOfDependentChildren>2</eeSummary:numberOfDependentChildren>
         </eeSummary:financialStatement>
       </eeSummary:financialsInfo>

--- a/test/data/conformance/no-financials-spouse.xml
+++ b/test/data/conformance/no-financials-spouse.xml
@@ -130,6 +130,35 @@
               <eeSummary:type>10</eeSummary:type>
             </eeSummary:income>
           </eeSummary:incomes>
+          <eeSummary:spouseFinancialsList>
+            <eeSummary:spouseFinancials>
+              <eeSummary:spouse>
+                <eeSummary:dob>04/06/1980</eeSummary:dob>
+                <eeSummary:givenName>FIRSTSPOUSE</eeSummary:givenName>
+                <eeSummary:middleName>MIDDLESPOUSE</eeSummary:middleName>
+                <eeSummary:familyName>LASTSPOUSE</eeSummary:familyName>
+                <eeSummary:suffix>SR.</eeSummary:suffix>
+                <eeSummary:relationship>2</eeSummary:relationship>
+                <eeSummary:startDate>05/10/1983</eeSummary:startDate>
+                <eeSummary:ssns>
+                  <eeSummary:ssn>
+                    <eeSummary:ssnText>111221234</eeSummary:ssnText>
+                  </eeSummary:ssn>
+                </eeSummary:ssns>
+                <eeSummary:address>
+                  <eeSummary:city>Dulles</eeSummary:city>
+                  <eeSummary:country>USA</eeSummary:country>
+                  <eeSummary:line1>123 NW 8th St</eeSummary:line1>
+                  <eeSummary:state>VA</eeSummary:state>
+                  <eeSummary:zipCode>20101</eeSummary:zipCode>
+                  <eeSummary:zipPlus4>0101</eeSummary:zipPlus4>
+                  <eeSummary:phoneNumber>1112221234</eeSummary:phoneNumber>
+                </eeSummary:address>
+              </eeSummary:spouse>
+              <eeSummary:contributedToSpousalSupport>false</eeSummary:contributedToSpousalSupport>
+              <eeSummary:livedWithPatient>true</eeSummary:livedWithPatient>
+            </eeSummary:spouseFinancials>
+          </eeSummary:spouseFinancialsList>
           <eeSummary:marriedLastCalendarYear>true</eeSummary:marriedLastCalendarYear>
           <eeSummary:dependentFinancialsList>
             <eeSummary:dependentFinancials>


### PR DESCRIPTION
Per Josh, we should include this data again even if there's no financial data present for the spouse or dependents themselves.
