### PR TITLE
More robust parsing of zip codes

### DIFF
--- a/src/server/enrollment-system.js
+++ b/src/server/enrollment-system.js
@@ -52,9 +52,9 @@ function formatAddress(address) {
   };
   if (address.country === 'USA') {
     formatted.state = address.state;
-    const splitZip = address.zipcode.split('-');
-    formatted.zipCode = splitZip[0];
-    formatted.zipPlus4 = validations.validateString(splitZip[1], 20, true) || undefined;
+    const numericZip = address.zipcode.replace(/\D/g, '');
+    formatted.zipCode = numericZip.substr(0, 5);
+    formatted.zipPlus4 = validations.validateString(numericZip.substr(5, 4), 20, true) || undefined;
   } else {
     formatted.provinceCode = address.state || address.provinceCode;
     formatted.postalCode = address.zipcode || address.postalCode;

--- a/test/data/conformance/no-children.json
+++ b/test/data/conformance/no-children.json
@@ -30,7 +30,7 @@
     "city": "Washington",
     "country": "USA",
     "state": "DC",
-    "zipcode": "20005"
+    "zipcode": "20005 1234"
   },
   "email": "foo@example.com",
   "homePhone": "1231241234",
@@ -53,7 +53,7 @@
     "city": "Dulles",
     "country": "USA",
     "state": "VA",
-    "zipcode": "20101"
+    "zipcode": "201016789"
   },
   "spousePhone": "1112221234",
   "children": [

--- a/test/data/conformance/no-children.xml
+++ b/test/data/conformance/no-children.xml
@@ -14,6 +14,7 @@
             <eeSummary:line1>123 NW 8th St</eeSummary:line1>
             <eeSummary:state>VA</eeSummary:state>
             <eeSummary:zipCode>20101</eeSummary:zipCode>
+            <eeSummary:zipPlus4>6789</eeSummary:zipPlus4>
           </eeSummary:address>
           <eeSummary:givenName>FIRSTSPOUSE</eeSummary:givenName>
           <eeSummary:middleName>MIDDLESPOUSE</eeSummary:middleName>
@@ -33,6 +34,7 @@
               <eeSummary:line1>123 NW 5th St</eeSummary:line1>
               <eeSummary:state>DC</eeSummary:state>
               <eeSummary:zipCode>20005</eeSummary:zipCode>
+              <eeSummary:zipPlus4>1234</eeSummary:zipPlus4>
               <eeSummary:addressTypeCode>P</eeSummary:addressTypeCode>
             </eeSummary:address>
           </eeSummary:addresses>

--- a/test/server/enrollment-system.spec.js
+++ b/test/server/enrollment-system.spec.js
@@ -43,7 +43,7 @@ describe('enrollment-system base tests', () => {
                     'no-children', 'no-spouse', 'only-vet',
                     'canadian-vet', 'australian-vet',
                     'no-financials-spouse', 'no-financials-children'];
-    for (const filename of checks) {
+    checks.forEach(filename => {
       it(`should serialize ${filename} correctly`, (done) => {
         const application = require(`../data/conformance/${filename}`);
         const valid = validate(application);
@@ -59,7 +59,7 @@ describe('enrollment-system base tests', () => {
           client.saveSubmitForm(input, (_submitError, _result) => {});
         });
       });
-    }
+    });
 
     it('should become a valid SOAP request', (done) => {
       // build the json to be sent through the SOAP service


### PR DESCRIPTION
Addresses this [issue](https://github.com/department-of-veterans-affairs/healthcare-application-team/issues/477). 

It's not clear to me if/how we should handle zip codes that aren't 5 or 9 digits. This change should work the same as what would happen with 12345-12 before.

Also, only the first conformance test was actually running, so that's fixed now, too.
