### PR TITLE
Use the same email regex for front and back end validations

### DIFF
--- a/src/common/schema/application.js
+++ b/src/common/schema/application.js
@@ -243,7 +243,8 @@ module.exports = {
     },
     email: {
       type: 'string',
-      pattern: '^(([a-zA-Z]|[0-9])|([-]|[_]|[.]))+[@](([a-zA-Z0-9])|([-])){2,63}[.](([a-zA-Z0-9]){2,63})+$' // Email pattern from RegEx 101 https://regex101.com/
+      // regex from client/validations.js' isValidEmail, with some extra escaping
+      pattern: '^(([^<>()\\[\\]\\\\.,;:\\s@"]+(\\.[^<>()\\[\\]\\\\.,;:\\s@"]+)*)|(".+"))@((\\[[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}])|(([a-zA-Z\\-0-9]+\\.)+[a-zA-Z]{2,}))$'
     },
     homePhone: {
       $ref: '#/definitions/phone'

--- a/test/data/conformance/no-financials-spouse.json
+++ b/test/data/conformance/no-financials-spouse.json
@@ -34,7 +34,7 @@
     "zipcode": "21231",
     "postalCode": "13AA"
   },
-  "email": "foo@example.com",
+  "email": "foo@examp.le",
   "homePhone": "1231241234",
   "mobilePhone": "1235551234",
   "understandsFinancialDisclosure": true,

--- a/test/data/conformance/no-financials-spouse.xml
+++ b/test/data/conformance/no-financials-spouse.xml
@@ -55,7 +55,7 @@
           </eeSummary:addresses>
           <eeSummary:emails>
             <eeSummary:email>
-              <eeSummary:address>foo@example.com</eeSummary:address>
+              <eeSummary:address>foo@examp.le</eeSummary:address>
               <eeSummary:type>1</eeSummary:type>
             </eeSummary:email>
           </eeSummary:emails>

--- a/test/data/conformance/no-spouse.json
+++ b/test/data/conformance/no-spouse.json
@@ -32,7 +32,7 @@
     "state": "DC",
     "zipcode": "20005"
   },
-  "email": "foo@example.com",
+  "email": "foo_bar@example.com",
   "homePhone": "1231241234",
   "mobilePhone": "1235551234",
   "understandsFinancialDisclosure": true,

--- a/test/data/conformance/no-spouse.xml
+++ b/test/data/conformance/no-spouse.xml
@@ -39,7 +39,7 @@
           </eeSummary:addresses>
           <eeSummary:emails>
             <eeSummary:email>
-              <eeSummary:address>foo@example.com</eeSummary:address>
+              <eeSummary:address>foo_bar@example.com</eeSummary:address>
               <eeSummary:type>1</eeSummary:type>
             </eeSummary:email>
           </eeSummary:emails>

--- a/test/data/conformance/only-vet.json
+++ b/test/data/conformance/only-vet.json
@@ -32,7 +32,7 @@
     "state": "DC",
     "zipcode": "20005-5500"
   },
-  "email": "foo@example.com",
+  "email": "foo.bar+va@example.com",
   "homePhone": "1231241234",
   "mobilePhone": "1235551234",
   "understandsFinancialDisclosure": true,

--- a/test/data/conformance/only-vet.xml
+++ b/test/data/conformance/only-vet.xml
@@ -22,7 +22,7 @@
           </eeSummary:addresses>
           <eeSummary:emails>
             <eeSummary:email>
-              <eeSummary:address>foo@example.com</eeSummary:address>
+              <eeSummary:address>foo.bar+va@example.com</eeSummary:address>
               <eeSummary:type>1</eeSummary:type>
             </eeSummary:email>
           </eeSummary:emails>

--- a/test/data/conformance/spouse-financial.json
+++ b/test/data/conformance/spouse-financial.json
@@ -32,7 +32,7 @@
     "state": "DC",
     "zipcode": "20005"
   },
-  "email": "foo@example.com",
+  "email": "foo.bar@example.com",
   "homePhone": "1231241234",
   "mobilePhone": "1235551234",
   "understandsFinancialDisclosure": true,

--- a/test/data/conformance/spouse-financial.xml
+++ b/test/data/conformance/spouse-financial.xml
@@ -38,7 +38,7 @@
           </eeSummary:addresses>
           <eeSummary:emails>
             <eeSummary:email>
-              <eeSummary:address>foo@example.com</eeSummary:address>
+              <eeSummary:address>foo.bar@example.com</eeSummary:address>
               <eeSummary:type>1</eeSummary:type>
             </eeSummary:email>
           </eeSummary:emails>


### PR DESCRIPTION
Looking at Cloudwatch, we have a lot of form validation errors where the emails aren't accepted by what's defined in the json schema. Using the same validation in as the react component should reduce those.
