### PR TITLE
Make child income required

### DIFF
--- a/src/client/components/household-information/AnnualIncomeSection.jsx
+++ b/src/client/components/household-information/AnnualIncomeSection.jsx
@@ -5,7 +5,7 @@ import _ from 'lodash';
 import ChildIncome from './ChildIncome';
 import ErrorableTextInput from '../form-elements/ErrorableTextInput';
 import FixedTable from '../form-elements/FixedTable.jsx';
-import { isValidField, isValidMonetaryValue } from '../../utils/validations';
+import { getMonetaryErrorMessage } from '../../utils/messages';
 import { veteranUpdateField } from '../../actions';
 
 /**
@@ -14,18 +14,6 @@ import { veteranUpdateField } from '../../actions';
  * `reviewSection` - Boolean. Hides components that are only needed for ReviewAndSubmitSection.
  */
 class AnnualIncomeSection extends React.Component {
-
-  getRequiredErrorMessage(field) {
-    let result;
-    if (isValidField(isValidMonetaryValue, field)) {
-      if (field.dirty && field.value === '') {
-        result = 'Please enter a number.';
-      }
-    } else {
-      result = 'Please enter only numbers and a decimal point if necessary (no commas or currency signs)';
-    }
-    return result;
-  }
 
   handleChange(field, update) {
     this.props.onStateChange(field, update);
@@ -77,7 +65,7 @@ class AnnualIncomeSection extends React.Component {
     let spouseIncomeReview;
     let content;
 
-    const message = this.getRequiredErrorMessage;
+    const message = getMonetaryErrorMessage;
 
     if (this.props.data.hasChildrenToReport.value === 'Y') {
       childrenIncomeInput = (

--- a/src/client/components/household-information/AnnualIncomeSection.jsx
+++ b/src/client/components/household-information/AnnualIncomeSection.jsx
@@ -8,24 +8,24 @@ import FixedTable from '../form-elements/FixedTable.jsx';
 import { isValidField, isValidMonetaryValue } from '../../utils/validations';
 import { veteranUpdateField } from '../../actions';
 
-function getRequiredErrorMessage(field) {
-  let result;
-  if (isValidField(isValidMonetaryValue, field)) {
-    if (field.dirty && field.value === '') {
-      result = 'Please enter a number.';
-    }
-  } else {
-    result = 'Please enter only numbers and a decimal point if necessary (no commas or currency signs)';
-  }
-  return result;
-}
-
 /**
  * Props:
  * `isSectionComplete` - Boolean. Marks the section as completed. Provides styles for completed sections.
  * `reviewSection` - Boolean. Hides components that are only needed for ReviewAndSubmitSection.
  */
 class AnnualIncomeSection extends React.Component {
+
+  getRequiredErrorMessage(field) {
+    let result;
+    if (isValidField(isValidMonetaryValue, field)) {
+      if (field.dirty && field.value === '') {
+        result = 'Please enter a number.';
+      }
+    } else {
+      result = 'Please enter only numbers and a decimal point if necessary (no commas or currency signs)';
+    }
+    return result;
+  }
 
   handleChange(field, update) {
     this.props.onStateChange(field, update);
@@ -77,6 +77,8 @@ class AnnualIncomeSection extends React.Component {
     let spouseIncomeReview;
     let content;
 
+    const message = this.getRequiredErrorMessage;
+
     if (this.props.data.hasChildrenToReport.value === 'Y') {
       childrenIncomeInput = (
         <div className="input-section">
@@ -117,21 +119,21 @@ class AnnualIncomeSection extends React.Component {
         <div className="input-section">
           <h6>Spouse</h6>
           <ErrorableTextInput required
-              errorMessage={getRequiredErrorMessage(this.props.data.spouseGrossIncome)}
+              errorMessage={message(this.props.data.spouseGrossIncome)}
               label="Spouse Gross Annual Income from Employment"
               name="spouseGrossIncome"
               field={this.props.data.spouseGrossIncome}
               onValueChange={(update) => {this.props.onStateChange('spouseGrossIncome', update);}}/>
 
           <ErrorableTextInput required
-              errorMessage={getRequiredErrorMessage(this.props.data.spouseNetIncome)}
+              errorMessage={message(this.props.data.spouseNetIncome)}
               label="Spouse Net Income from your Farm, Ranch, Property or Business"
               name="spouseNetIncome"
               field={this.props.data.spouseNetIncome}
               onValueChange={(update) => {this.props.onStateChange('spouseNetIncome', update);}}/>
 
           <ErrorableTextInput required
-              errorMessage={getRequiredErrorMessage(this.props.data.spouseOtherIncome)}
+              errorMessage={message(this.props.data.spouseOtherIncome)}
               label="Spouse Other Income Amount"
               name="spouseOtherIncome"
               field={this.props.data.spouseOtherIncome}
@@ -194,21 +196,21 @@ class AnnualIncomeSection extends React.Component {
           <div className="input-section">
             <h6>Veteran</h6>
             <ErrorableTextInput required
-                errorMessage={getRequiredErrorMessage(this.props.data.veteranGrossIncome)}
+                errorMessage={message(this.props.data.veteranGrossIncome)}
                 label="Veteran gross annual income from employment"
                 name="veteranGrossIncome"
                 field={this.props.data.veteranGrossIncome}
                 onValueChange={(update) => {this.handleChange('veteranGrossIncome', update); }}/>
 
             <ErrorableTextInput required
-                errorMessage={getRequiredErrorMessage(this.props.data.veteranNetIncome)}
+                errorMessage={message(this.props.data.veteranNetIncome)}
                 label="Veteran Net Income from your Farm, Ranch, Property or Business"
                 name="veteranNetIncome"
                 field={this.props.data.veteranNetIncome}
                 onValueChange={(update) => {this.handleChange('veteranNetIncome', update); }}/>
 
             <ErrorableTextInput required
-                errorMessage={getRequiredErrorMessage(this.props.data.veteranOtherIncome)}
+                errorMessage={message(this.props.data.veteranOtherIncome)}
                 label="Veteran Other Income Amount"
                 name="veteranOtherIncome"
                 field={this.props.data.veteranOtherIncome}

--- a/src/client/components/household-information/ChildIncome.jsx
+++ b/src/client/components/household-information/ChildIncome.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import ErrorableTextInput from '../form-elements/ErrorableTextInput';
 
-import { isBlank, isValidMonetaryValue, validateIfDirty } from '../../utils/validations';
+import { isValidField, isValidMonetaryValue } from '../../utils/validations';
 
 /**
  * Sub-component for children income portion AnnualIncomeSection.
@@ -12,26 +12,39 @@ import { isBlank, isValidMonetaryValue, validateIfDirty } from '../../utils/vali
  * `onValueChange` - a function with this prototype: (newValue)
  */
 class ChildIncome extends React.Component {
+
+  getRequiredErrorMessage(field) {
+    let result;
+    if (isValidField(isValidMonetaryValue, field)) {
+      if (field.dirty && field.value === '') {
+        result = 'Please enter a number.';
+      }
+    } else {
+      result = 'Please enter only numbers and a decimal point if necessary (no commas or currency signs)';
+    }
+    return result;
+  }
+
   render() {
-    const message = 'Please enter only numbers and a decimal point if necessary (no commas or currency signs)';
+    const message = this.getRequiredErrorMessage;
 
     return (
       <div>
         <h6>Child: {`${this.props.data.childFullName.first.value} ${this.props.data.childFullName.last.value}`}</h6>
-        <ErrorableTextInput
-            errorMessage={validateIfDirty(this.props.data.grossIncome, isBlank) || validateIfDirty(this.props.data.grossIncome, isValidMonetaryValue) ? undefined : message}
+        <ErrorableTextInput required
+            errorMessage={message(this.props.data.grossIncome)}
             label="Child Gross Annual Income from Employment"
             name="childGrossIncome"
             field={this.props.data.grossIncome}
             onValueChange={(update) => {this.props.onValueChange('grossIncome', update);}}/>
-        <ErrorableTextInput
-            errorMessage={validateIfDirty(this.props.data.netIncome, isBlank) || validateIfDirty(this.props.data.netIncome, isValidMonetaryValue) ? undefined : message}
+        <ErrorableTextInput required
+            errorMessage={message(this.props.data.netIncome)}
             label="Child Net Income from your Farm, Ranch, Property or Business"
             name="childNetIncome"
             field={this.props.data.netIncome}
             onValueChange={(update) => {this.props.onValueChange('netIncome', update);}}/>
-        <ErrorableTextInput
-            errorMessage={validateIfDirty(this.props.data.otherIncome, isBlank) || validateIfDirty(this.props.data.otherIncome, isValidMonetaryValue) ? undefined : message}
+        <ErrorableTextInput required
+            errorMessage={message(this.props.data.otherIncome)}
             label="Child Other Income Amount"
             name="ChildOtherIncome"
             field={this.props.data.otherIncome}

--- a/src/client/components/household-information/ChildIncome.jsx
+++ b/src/client/components/household-information/ChildIncome.jsx
@@ -46,7 +46,7 @@ class ChildIncome extends React.Component {
         <ErrorableTextInput required
             errorMessage={message(this.props.data.otherIncome)}
             label="Child Other Income Amount"
-            name="ChildOtherIncome"
+            name="childOtherIncome"
             field={this.props.data.otherIncome}
             onValueChange={(update) => {this.props.onValueChange('otherIncome', update);}}/>
       </div>

--- a/src/client/components/household-information/ChildIncome.jsx
+++ b/src/client/components/household-information/ChildIncome.jsx
@@ -1,8 +1,7 @@
 import React from 'react';
 
 import ErrorableTextInput from '../form-elements/ErrorableTextInput';
-
-import { isValidField, isValidMonetaryValue } from '../../utils/validations';
+import { getMonetaryErrorMessage } from '../../utils/messages';
 
 /**
  * Sub-component for children income portion AnnualIncomeSection.
@@ -13,20 +12,8 @@ import { isValidField, isValidMonetaryValue } from '../../utils/validations';
  */
 class ChildIncome extends React.Component {
 
-  getRequiredErrorMessage(field) {
-    let result;
-    if (isValidField(isValidMonetaryValue, field)) {
-      if (field.dirty && field.value === '') {
-        result = 'Please enter a number.';
-      }
-    } else {
-      result = 'Please enter only numbers and a decimal point if necessary (no commas or currency signs)';
-    }
-    return result;
-  }
-
   render() {
-    const message = this.getRequiredErrorMessage;
+    const message = getMonetaryErrorMessage;
 
     return (
       <div>

--- a/src/client/utils/messages.js
+++ b/src/client/utils/messages.js
@@ -1,0 +1,17 @@
+import { isBlank, isDirty, isValidMonetaryValue } from './validations';
+
+const getMonetaryErrorMessage = (field) => {
+  let result;
+  if (isDirty(field)) {
+    if (isBlank(field.value)) {
+      result = 'Please enter a number.';
+    } else if (!isValidMonetaryValue(field.value)) {
+      result = 'Please enter only numbers and a decimal point if necessary (no commas or currency signs)';
+    }
+  }
+  return result;
+};
+
+module.exports = {
+  getMonetaryErrorMessage
+};

--- a/src/client/utils/validations.js
+++ b/src/client/utils/validations.js
@@ -29,6 +29,10 @@ function isBlank(value) {
   return value === '';
 }
 
+function isDirty(field) {
+  return field.dirty;
+}
+
 function isNotBlank(value) {
   return value !== '';
 }
@@ -472,6 +476,7 @@ export {
   validateIfDirtyDate,
   validateIfDirtyProvider,
   initializeNullValues,
+  isDirty,
   isBlank,
   isNotBlank,
   isValidDate,

--- a/src/client/utils/validations.js
+++ b/src/client/utils/validations.js
@@ -267,10 +267,10 @@ function isValidFinancialDisclosure(data) {
   return validateIfDirty(data.understandsFinancialDisclosure, isNotBlank);
 }
 
-function isValidIncome(income) {
-  return isValidField(isValidMonetaryValue, income.grossIncome) &&
-      isValidField(isValidMonetaryValue, income.netIncome) &&
-      isValidField(isValidMonetaryValue, income.otherIncome);
+function isValidRequiredIncome(income) {
+  return isValidRequiredField(isValidMonetaryValue, income.grossIncome) &&
+      isValidRequiredField(isValidMonetaryValue, income.netIncome) &&
+      isValidRequiredField(isValidMonetaryValue, income.otherIncome);
 }
 
 function isValidSpouseInformation(data) {
@@ -328,7 +328,7 @@ function isValidChildren(data) {
 
 function isValidChildrenIncome(children) {
   for (let i = 0; i < children.length; i++) {
-    if (!isValidIncome(children[i])) {
+    if (!isValidRequiredIncome(children[i])) {
       return false;
     }
   }

--- a/test/e2e/tests/01-required-and-optional.js
+++ b/test/e2e/tests/01-required-and-optional.js
@@ -211,7 +211,7 @@ module.exports = {
       .setValue('input[name="spouseOtherIncome"]', '5000')
       .setValue('input[name="childGrossIncome"]', '4000')
       .setValue('input[name="childNetIncome"]', '3000')
-      .setValue('input[name="ChildOtherIncome"]', '2000')
+      .setValue('input[name="childOtherIncome"]', '2000')
       .click('.form-panel .usa-button-primary');
     expectNavigateAwayFrom(client, '/household-information/annual-income');
 

--- a/test/e2e/tests/02-fields-initialized.js
+++ b/test/e2e/tests/02-fields-initialized.js
@@ -191,7 +191,6 @@ module.exports = {
     expectInputToNotBeSelected(client, 'input[name="provideSupportLastYear-0"]');
     expectInputToNotBeSelected(client, 'input[name="provideSupportLastYear-1"]');
     common.completeSpouseInformation(client, common.testValues, true);
-    client.pause(30000);
     client.click('.form-panel .usa-button-primary');
     expectNavigateAwayFrom(client, '/household-information/spouse-information');
 
@@ -239,7 +238,7 @@ module.exports = {
     expectValueToBeBlank(client, 'input[name="spouseOtherIncome"]');
     expectValueToBeBlank(client, 'input[name="childGrossIncome"]');
     expectValueToBeBlank(client, 'input[name="childNetIncome"]');
-    expectValueToBeBlank(client, 'input[name="ChildOtherIncome"]');
+    expectValueToBeBlank(client, 'input[name="childOtherIncome"]');
     common.completeAnnualIncomeInformation(client, common.testValues);
     client.click('.form-panel .usa-button-primary');
     expectNavigateAwayFrom(client, '/household-information/annual-income');

--- a/test/e2e/utils/common.js
+++ b/test/e2e/utils/common.js
@@ -358,7 +358,10 @@ function completeAnnualIncomeInformation(client, data, onlyRequiredFields) {
     client
       .setValue('input[name="spouseGrossIncome"]', data.spouseGrossIncome)
       .setValue('input[name="spouseNetIncome"]', data.spouseNetIncome)
-      .setValue('input[name="spouseOtherIncome"]', data.spouseOtherIncome);
+      .setValue('input[name="spouseOtherIncome"]', data.spouseOtherIncome)
+      .setValue('input[name="childGrossIncome"]', data.children[0].grossIncome)
+      .setValue('input[name="childNetIncome"]', data.children[0].netIncome)
+      .setValue('input[name="childOtherIncome"]', data.children[0].otherIncome);
   }
 }
 


### PR DESCRIPTION
This addresses [#494](https://github.com/department-of-veterans-affairs/healthcare-application-team/issues/494)

There's a [known issue](https://github.com/department-of-veterans-affairs/healthcare-application-team/issues/497) that sets each child income field to its error state even before the user has interacted with it.

![image](https://cloud.githubusercontent.com/assets/627264/20018846/c4922fe0-a286-11e6-856c-c7b75c8afdae.png)
