### PR TITLE
Move location of marital status

### DIFF
--- a/src/client/components/HealthCareApp.jsx
+++ b/src/client/components/HealthCareApp.jsx
@@ -28,6 +28,7 @@ class HealthCareApp extends React.Component {
     this.handleBack = this.handleBack.bind(this);
     this.handleContinue = this.handleContinue.bind(this);
     this.handleSubmit = this.handleSubmit.bind(this);
+    this.checkDependencies = this.checkDependencies.bind(this);
     this.getUrl = this.getUrl.bind(this);
     this.removeOnbeforeunload = this.removeOnbeforeunload.bind(this);
     this.onbeforeunload = this.onbeforeunload.bind(this);
@@ -68,7 +69,7 @@ class HealthCareApp extends React.Component {
       const route = routes[i + increment];
       if (route) {
         // Check to see if we should skip the next route
-        if (route.depends !== undefined && !_.matches(route.depends)(data)) {
+        if (route.depends !== undefined && !this.checkDependencies(route.depends, data)) {
           if (markAsComplete) {
             this.props.onCompletedStatus(route.path);
           }
@@ -81,6 +82,16 @@ class HealthCareApp extends React.Component {
     }
 
     return nextPath;
+  }
+
+  checkDependencies(depends, data) {
+    const arr = _.isArray(depends) ? depends : [depends];
+    for (let i = 0; i < arr.length; i++) {
+      if (_.matches(arr[i])(data)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   removeOnbeforeunload() {

--- a/src/client/components/household-information/SpouseInformationSection.jsx
+++ b/src/client/components/household-information/SpouseInformationSection.jsx
@@ -3,12 +3,11 @@ import { connect } from 'react-redux';
 
 import Address from '../questions/Address';
 import DateInput from '../form-elements/DateInput';
-import ErrorableSelect from '../form-elements/ErrorableSelect';
 import ErrorableRadioButtons from '../form-elements/ErrorableRadioButtons';
 import FullName from '../questions/FullName';
 import Phone from '../questions/Phone';
 import SocialSecurityNumber from '../questions/SocialSecurityNumber';
-import { maritalStatuses, yesNo } from '../../utils/options-for-select.js';
+import { yesNo } from '../../utils/options-for-select.js';
 import { isNotBlank, validateIfDirty, isValidMarriageDate } from '../../utils/validations';
 import { veteranUpdateField, updateSpouseAddress } from '../../actions';
 
@@ -191,12 +190,6 @@ class SpouseInformationSection extends React.Component {
     if (this.props.isSectionComplete && this.props.reviewSection) {
       content = (<div>
         <table className="review usa-table-borderless">
-          <tbody>
-            <tr>
-              <td>Martial Status:</td>
-              <td>{this.props.data.maritalStatus.value}</td>
-            </tr>
-          </tbody>
           {spouseInformationSummary}
         </table>
         {spouseAddressSummary}
@@ -207,14 +200,6 @@ class SpouseInformationSection extends React.Component {
         <p>(<span className="hca-required-span">*</span>) Indicates a required field</p>
         <p>Please fill this out to the best of your knowledge. The more accurate your responses, the faster we can process your application.</p>
         <div className="input-section">
-          <ErrorableSelect
-              errorMessage={validateIfDirty(this.props.data.maritalStatus, isNotBlank) ? undefined : 'Please select a marital status'}
-              label="Current marital status"
-              name="maritalStatus"
-              options={maritalStatuses}
-              required
-              value={this.props.data.maritalStatus}
-              onValueChange={(update) => {this.props.onStateChange('maritalStatus', update);}}/>
           {spouseInformationFields}
           {spouseAddressFields}
         </div>

--- a/src/client/components/veteran-information/DemographicInformationSection.jsx
+++ b/src/client/components/veteran-information/DemographicInformationSection.jsx
@@ -2,7 +2,10 @@ import React from 'react';
 import { connect } from 'react-redux';
 
 import ErrorableCheckbox from '../form-elements/ErrorableCheckbox';
+import ErrorableSelect from '../form-elements/ErrorableSelect';
 import Gender from '../questions/Gender';
+import { maritalStatuses } from '../../utils/options-for-select.js';
+import { validateIfDirty, isNotBlank } from '../../utils/validations';
 import { veteranUpdateField } from '../../actions';
 
 /**
@@ -21,6 +24,10 @@ class DemographicInformationSection extends React.Component {
             <tr>
               <td>Gender:</td>
               <td>{this.props.data.gender.value}</td>
+            </tr>
+            <tr>
+              <td>Martial Status:</td>
+              <td>{this.props.data.maritalStatus.value}</td>
             </tr>
           </tbody>
         </table>
@@ -62,6 +69,14 @@ class DemographicInformationSection extends React.Component {
           <Gender required
               value={this.props.data.gender}
               onUserInput={(update) => {this.props.onStateChange('gender', update);}}/>
+
+          <ErrorableSelect required
+              errorMessage={validateIfDirty(this.props.data.maritalStatus, isNotBlank) ? undefined : 'Please select a marital status'}
+              label="Current marital status"
+              name="maritalStatus"
+              options={maritalStatuses}
+              value={this.props.data.maritalStatus}
+              onValueChange={(update) => {this.props.onStateChange('maritalStatus', update);}}/>
         </div>
 
         <div className="input-section">

--- a/src/client/reducers/uiState/index.js
+++ b/src/client/reducers/uiState/index.js
@@ -33,7 +33,7 @@ const ui = {
     '/veteran-information/demographic-information': {
       complete: false,
       verified: false,
-      fields: ['gender', 'isSpanishHispanicLatino', 'isAmericanIndianOrAlaskanNative', 'isBlackOrAfricanAmerican', 'isNativeHawaiianOrOtherPacificIslander', 'isAsian', 'isWhite']
+      fields: ['gender', 'maritalStatus', 'isSpanishHispanicLatino', 'isAmericanIndianOrAlaskanNative', 'isBlackOrAfricanAmerican', 'isNativeHawaiianOrOtherPacificIslander', 'isAsian', 'isWhite']
     },
     '/veteran-information/veteran-address': {
       complete: false,
@@ -68,7 +68,7 @@ const ui = {
     '/household-information/spouse-information': {
       complete: false,
       verified: false,
-      fields: ['maritalStatus', 'spouseFullName', 'spouseSocialSecurityNumber', 'spouseDateOfBirth', 'dateOfMarriage', 'sameAddress', 'cohabitedLastYear', 'provideSupportLastYear', 'spouseAddress', 'spousePhone']
+      fields: ['spouseFullName', 'spouseSocialSecurityNumber', 'spouseDateOfBirth', 'dateOfMarriage', 'sameAddress', 'cohabitedLastYear', 'provideSupportLastYear', 'spouseAddress', 'spousePhone']
     },
     '/household-information/child-information': {
       complete: false,

--- a/src/client/routes.jsx
+++ b/src/client/routes.jsx
@@ -73,7 +73,10 @@ const routes = [
       path="/household-information/financial-disclosure"/>,
   <Route
       component={SpouseInformationSection}
-      depends={{ understandsFinancialDisclosure: { value: 'Y' }, maritalStatus: { value: ['Married', 'Separated'] } }}
+      depends={[
+        { understandsFinancialDisclosure: { value: 'Y' }, maritalStatus: { value: 'Married' } },
+        { understandsFinancialDisclosure: { value: 'Y' }, maritalStatus: { value: 'Separated' } },
+      ]}
       key="/household-information/spouse-information"
       path="/household-information/spouse-information"/>,
   <Route

--- a/src/client/routes.jsx
+++ b/src/client/routes.jsx
@@ -73,7 +73,7 @@ const routes = [
       path="/household-information/financial-disclosure"/>,
   <Route
       component={SpouseInformationSection}
-      depends={{ understandsFinancialDisclosure: { value: 'Y' } }}
+      depends={{ understandsFinancialDisclosure: { value: 'Y' }, maritalStatus: { value: ['Married', 'Separated'] } }}
       key="/household-information/spouse-information"
       path="/household-information/spouse-information"/>,
   <Route

--- a/test/e2e/tests/01-required-and-optional.js
+++ b/test/e2e/tests/01-required-and-optional.js
@@ -60,6 +60,7 @@ module.exports = {
     client.expect.element('select[name="gender"]').to.be.visible;
     client
       .setValue('select[name="gender"]', 'M')
+      .setValue('select[name="maritalStatus"]', 'Married')
       .click('input[name="isAmericanIndianOrAlaskanNative"]')
       .click('input[name="isBlackOrAfricanAmerican"]')
       .click('input[name="isNativeHawaiianOrOtherPacificIslander"]')
@@ -139,10 +140,6 @@ module.exports = {
     expectNavigateAwayFrom(client, '/household-information/financial-disclosure');
 
     // Spouse information Page.
-    client.expect.element('select[name="maritalStatus"]').to.be.visible;
-    client
-      .setValue('select[name="maritalStatus"]', 'Married')
-      .click('.form-panel');
     client.expect.element('input[name="fname"]').to.be.visible.before(common.timeouts.normal);
 
     client

--- a/test/e2e/tests/02-fields-initialized.js
+++ b/test/e2e/tests/02-fields-initialized.js
@@ -73,6 +73,7 @@ module.exports = {
     // Demographic information page.
     client.expect.element('select[name="gender"]').to.be.visible;
     expectValueToBeBlank(client, 'select[name="gender"]');
+    expectValueToBeBlank(client, 'select[name="maritalStatus"]');
     expectInputToNotBeSelected(client, 'input[name="isAmericanIndianOrAlaskanNative"]');
     expectInputToNotBeSelected(client, 'input[name="isBlackOrAfricanAmerican"]');
     expectInputToNotBeSelected(client, 'input[name="isNativeHawaiianOrOtherPacificIslander"]');

--- a/test/e2e/tests/02-fields-initialized.js
+++ b/test/e2e/tests/02-fields-initialized.js
@@ -157,12 +157,6 @@ module.exports = {
     expectNavigateAwayFrom(client, '/household-information/financial-disclosure');
 
     // Spouse information Page.
-    client.expect.element('select[name="maritalStatus"]').to.be.visible;
-    expectValueToBeBlank(client, 'select[name="maritalStatus"]');
-    client
-      .setValue('select[name="maritalStatus"]', 'Married')
-      .click('.form-panel');
-
     client.expect.element('input[name="fname"]').to.be.visible.before(common.timeouts.normal);
     expectValueToBeBlank(client, 'input[name="fname"]');
     expectValueToBeBlank(client, 'input[name="mname"]');

--- a/test/e2e/tests/06-edit-submission.js
+++ b/test/e2e/tests/06-edit-submission.js
@@ -192,7 +192,7 @@ module.exports = {
     vetInfoCopy.spouseFullName.first = 'Anne';
     editSection(client);
     common.completeSpouseInformation(client, vetInfoCopy, true);
-    verifyEdit(client, 'Anne');
+    verifyEdit(client, 'Anne Hathaway');
 
     client.click('.form-panel .usa-button-primary');
     client.expect.element('.js-test-location').attribute('data-location')

--- a/test/e2e/tests/06-edit-submission.js
+++ b/test/e2e/tests/06-edit-submission.js
@@ -189,10 +189,10 @@ module.exports = {
     nextSection(client);
 
     // Edit spouse information
-    vetInfoCopy.maritalStatus = 'Separated';
+    vetInfoCopy.spouseFullName.first = 'Anne';
     editSection(client);
     common.completeSpouseInformation(client, vetInfoCopy, true);
-    verifyEdit(client, 'Separated');
+    verifyEdit(client, 'Anne');
 
     client.click('.form-panel .usa-button-primary');
     client.expect.element('.js-test-location').attribute('data-location')

--- a/test/e2e/utils/common.js
+++ b/test/e2e/utils/common.js
@@ -210,7 +210,10 @@ function completeBirthInformation(client, data, onlyRequiredFields) {
 }
 
 function completeDemographicInformation(client, data, onlyRequiredFields) {
-  client.setValue('select[name="gender"]', data.gender);
+  client
+    .setValue('select[name="gender"]', data.gender)
+    .clearValue('select[name="maritalStatus"]')
+    .setValue('select[name="maritalStatus"]', data.maritalStatus);
 
   if (!onlyRequiredFields) {
     client
@@ -296,12 +299,6 @@ function completeFinancialDisclosure(client, data, onlyRequiredFields) {
 }
 
 function completeSpouseInformation(client, data, onlyRequiredFields) {
-  client
-    .clearValue('select[name="maritalStatus"]')
-    .setValue('select[name="maritalStatus"]', data.maritalStatus)
-    .click('.form-panel');
-  client.expect.element('input[name="fname"]').to.be.visible.before(timeouts.normal);
-
   client
     .clearValue('input[name="fname"]')
     .setValue('input[name="fname"]', data.spouseFullName.first)


### PR DESCRIPTION
Moving marital status field out of spouse information section because not all users will now see this section, but marital status is required of all users.

Moving marital status to the demographic page after gender, and then making whether or not we show the spouse page conditional on if they are either Married or Separated.