### PR TITLE
Strip out characters we allow through on the FE before submitting to ES

### DIFF
--- a/src/common/veteran.js
+++ b/src/common/veteran.js
@@ -775,13 +775,18 @@ function veteranToApplication(veteran) {
       case 'cityOfBirth':
       case 'stateOfBirth':
       case 'email':
-      case 'homePhone':
-      case 'mobilePhone':
-      case 'spousePhone':
         if (value.value === '') {
           return undefined;
         }
         break;
+
+      case 'homePhone':
+      case 'mobilePhone':
+      case 'spousePhone':
+        if (value.value == '') {
+          return undefined
+        }
+        return value.value.replace(/[- )(]/g, '');
 
       default:
         // fall through.

--- a/src/common/veteran.js
+++ b/src/common/veteran.js
@@ -783,8 +783,8 @@ function veteranToApplication(veteran) {
       case 'homePhone':
       case 'mobilePhone':
       case 'spousePhone':
-        if (value.value == '') {
-          return undefined
+        if (value.value === '') {
+          return undefined;
         }
         return value.value.replace(/[- )(]/g, '');
 

--- a/test/server/utils/validations.spec.js
+++ b/test/server/utils/validations.spec.js
@@ -1,3 +1,4 @@
+const moment = require('moment');
 const validations = require('../../../src/server/utils/validations');
 const chai = require('chai');
 chai.should();
@@ -21,7 +22,7 @@ describe('validations', () => {
         convertedDate.should.be.empty;
       });
       it('if the date passed in is a string after today', () => {
-        const convertedDate = validations.dateOfBirth('2016-12-01');
+        const convertedDate = validations.dateOfBirth(moment().add(1, 'day').format('YYYY-MM-DD'));
         convertedDate.should.be.a('string');
         convertedDate.should.be.empty;
       });


### PR DESCRIPTION
We allow non-numeric characters through on the front-end for phone numbers. We just strip them out when validating the phone number: https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/js/common/utils/validations.js#L127.

We should actually strip out the characters on the BE before submitting to ES. Not sure if this is the right approach, but I'm sure @markolson can take a look at it and let me know :).